### PR TITLE
Bug fix: Move the fuser model to GPU before inference

### DIFF
--- a/llm_blender/blender/blender_utils.py
+++ b/llm_blender/blender/blender_utils.py
@@ -117,11 +117,13 @@ def load_fuser(fuser_config: GenFuserConfig):
             device_map={"": "cpu"}, torch_dtype=get_torch_dtype(fuser_config.torch_dtype),
         )
     else:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         fuser = AutoModelForSeq2SeqLM.from_pretrained(
             model_name, cache_dir=fuser_config.cache_dir,
             device_map="auto", torch_dtype=get_torch_dtype(fuser_config.torch_dtype),
             load_in_4bit=fuser_config.load_in_4bit, load_in_8bit=fuser_config.load_in_8bit,
         )
+        fuser.to(device)
     return fuser, tokenizer
 
 class RankerDataset(torch.utils.data.Dataset):


### PR DESCRIPTION
## Problem description
When running [this example](https://github.com/yuchenlin/LLM-Blender/blob/main/blender_usage.ipynb), I hit a torch error when running the code on my device which has GPU and CPU.
`RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cpu and cuda:0! ...`

**Environment**
* nvcc: v12.4
* Python: v2.12.7
* OS: Windows

## Proposed solution
Move the model to GPU when load the fuser.
*Note*: I'm not a python expert. Any feedback/recommendation is welcome.

## Test
Manually tested with [this example](https://github.com/yuchenlin/LLM-Blender/blob/main/blender_usage.ipynb).