### PR TITLE
fix bug: load configuration from json file

### DIFF
--- a/train_ranker.py
+++ b/train_ranker.py
@@ -6,6 +6,7 @@
 
 import os
 import argparse
+import json
 import torch
 import transformers
 import numpy as np
@@ -86,7 +87,9 @@ def main(args):
     # set up model
     
     if args.load_checkpoint:
-        config = RankerConfig.from_json_file(os.path.join(args.load_checkpoint, "config.json"))
+        with open(os.path.join(args.load_checkpoint, "config.json"), "r", encoding="utf-8") as f:
+            config_json = json.load(f)
+        config = RankerConfig.from_dict(config_json)
         for k in args.__dict__:
             if k in config.__dict__:
                 print(k, getattr(args, k))


### PR DESCRIPTION
The `dataclasses_json` library does not provide a `from_json_file` method.

Replaced the use of `from_json_file` with `from_dict`, aligning it with the correct method as used in the blender.py file [here](https://github.com/yuchenlin/LLM-Blender/blob/main/llm_blender/blender/blender.py#L120).