### PR TITLE
fix: add transformers v5 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 
 ## 🔥News
 
+- [2025/4/2] LLM-Blender is now compatible with **Transformers v5**! See the [changelog](https://github.com/kashif/LLM-Blender/tree/fix/transformers-v5) for details.
 - [2024/1/5] PairRM can now be directly loaded using Hugging face Wrapper `DebertaV2PairRM.from_pretrained("llm-blender/PairRM-hf")`, see more in our [🤗Model page](https://huggingface.co/llm-blender/PairRM-hf)
 - [2023/11/10] Glad to announce that our pairwise reward-model, 🤗[PairRM](https://huggingface.co/llm-blender/PairRM), has released. It's trained on high-quality and large-scale human reference dataset and approaches GPT-4's alignment with human preference with a extremly small model size (0.4B).
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## 🔥News
 
-- [2025/4/2] LLM-Blender is now compatible with **Transformers v5**! See the [changelog](https://github.com/kashif/LLM-Blender/tree/fix/transformers-v5) for details.
+- [2026/4/2] LLM-Blender is now compatible with **Transformers v5**! See the [changelog](https://github.com/kashif/LLM-Blender/tree/fix/transformers-v5) for details.
 - [2024/1/5] PairRM can now be directly loaded using Hugging face Wrapper `DebertaV2PairRM.from_pretrained("llm-blender/PairRM-hf")`, see more in our [🤗Model page](https://huggingface.co/llm-blender/PairRM-hf)
 - [2023/11/10] Glad to announce that our pairwise reward-model, 🤗[PairRM](https://huggingface.co/llm-blender/PairRM), has released. It's trained on high-quality and large-scale human reference dataset and approaches GPT-4's alignment with human preference with a extremly small model size (0.4B).
 

--- a/llm_blender/blender/blender.py
+++ b/llm_blender/blender/blender.py
@@ -9,29 +9,27 @@ import transformers
 from typing import List, Union
 from pathlib import Path
 from .blender_utils import (
-    load_ranker, 
+    load_ranker,
     load_other_ranker,
     load_fuser,
     RankerDataset,
     GenFuserDataset,
     get_topk_candidates_from_ranks,
-    get_torch_dtype
+    get_torch_dtype,
 )
-from ..gpt_eval.utils import (
-    get_scores_from_cmps,
-    get_ranks_from_scores
-)
+from ..gpt_eval.utils import get_scores_from_cmps, get_ranks_from_scores
 from ..pair_ranker.config import RankerConfig
 from ..gen_fuser.config import GenFuserConfig
 from .config import BlenderConfig
 from huggingface_hub import snapshot_download
-from transformers.utils.hub import TRANSFORMERS_CACHE
+from huggingface_hub.constants import HF_HOME
 from tqdm import tqdm
 
 # detect if vllm is installed
 try:
     importlib.import_module("vllm")
     import vllm
+
     is_vllm_imported = True
 except ImportError:
     is_vllm_imported = False
@@ -39,40 +37,50 @@ except ImportError:
 
 class Blender:
     def __init__(
-        self, 
-        blender_config:BlenderConfig=None,
-        ranker_config:RankerConfig=None,
-        fuser_config:GenFuserConfig=None,
+        self,
+        blender_config: BlenderConfig = None,
+        ranker_config: RankerConfig = None,
+        fuser_config: GenFuserConfig = None,
     ):
         """Initialize Blender
 
         Args:
-            blender_config (BlenderConfig, optional): 
+            blender_config (BlenderConfig, optional):
                 Defaults to None.
-            ranker_config (RankerConfig, optional): 
-                Defaults to None. 
+            ranker_config (RankerConfig, optional):
+                Defaults to None.
                 Load ranker from ranker_config with ranker_config.load_checkpoint
-            fuser_config (GenFuserConfig, optional): 
-                Defaults to None. 
+            fuser_config (GenFuserConfig, optional):
+                Defaults to None.
                 Load fuser from fuser_config with fuser_config.load_checkpoint
         """
         self.ranker_config = ranker_config
         self.fuser_config = fuser_config
         self.blender_config = blender_config or BlenderConfig()
-        
+
+        self.ranker = None
+        self.fuser = None
+        self.ranker_tokenizer = None
+        self.ranker_collator = None
+        self.fuser_tokenizer = None
+
         if self.ranker_config is None:
-            logging.warning("No ranker config provided, no ranker loaded, please load ranker first through load_ranker()")
+            logging.warning(
+                "No ranker config provided, no ranker loaded, please load ranker first through load_ranker()"
+            )
         else:
             ranker_path = self.ranker_config.load_checkpoint
             self.loadranker(ranker_path, **self.ranker_config.to_dict())
-        
+
         if self.fuser_config is None:
-            logging.warning("No fuser config provided, no fuser loaded, please load fuser first through load_fuser()")
+            logging.warning(
+                "No fuser config provided, no fuser loaded, please load fuser first through load_fuser()"
+            )
         else:
             fuser_path = self.fuser_config.model_name
             self.loadfuser(fuser_path, **self.fuser_config.to_dict())
-        
-    def loadranker(self, ranker_path:str, device:str=None, **kwargs):
+
+    def loadranker(self, ranker_path: str, device: str = None, **kwargs):
         """Load ranker from a path
             Supported rankers:
                 - llm-blender/pair-ranker
@@ -87,31 +95,44 @@ class Blender:
             ranker_path (str):
                 - Huggingface model path, e.g. "llm-blender/pair-ranker"
                 - Local path, e.g. "/path/to/ranker"
-            device (str): 
+            device (str):
                 cuda or cpu, or None. If None, will use self.blender_config.device
-            kwargs: 
+            kwargs:
                 kwargs for RankerConfig
-                
+
         """
-        cache_dir = kwargs.pop("cache_dir", TRANSFORMERS_CACHE)
+        if ranker_path is None:
+            raise ValueError(
+                "ranker_path cannot be None. Please provide a valid model path or set ranker_config.load_checkpoint"
+            )
+
+        cache_dir = kwargs.pop("cache_dir", None)
+        if cache_dir is None:
+            cache_dir = HF_HOME
         cache_dir = Path(cache_dir)
-        
+
         if not os.path.exists(ranker_path):
             if not os.path.exists(cache_dir / ranker_path):
                 logging.warning(f"Checkpoint '{ranker_path}' does not exist")
                 try:
                     # try hugging face hub
-                    logging.warning(f"Try dowloading checkpoint from huggingface hub: {ranker_path}")
+                    logging.warning(
+                        f"Try dowloading checkpoint from huggingface hub: {ranker_path}"
+                    )
                     snapshot_download(ranker_path, local_dir=cache_dir / ranker_path)
                     ranker_path = cache_dir / ranker_path
-                    logging.warning(f"Successfully downloaded checkpoint to '{ranker_path}'")
+                    logging.warning(
+                        f"Successfully downloaded checkpoint to '{ranker_path}'"
+                    )
                 except Exception as e:
                     # try local path
-                    logging.warning(f"Failed to download checkpoint from huggingface hub: {ranker_path}")
+                    logging.warning(
+                        f"Failed to download checkpoint from huggingface hub: {ranker_path}"
+                    )
                     logging.warning(f"Erorr: {e}")
             else:
                 ranker_path = cache_dir / ranker_path
-        
+
         # load ranker config from ranker_path
         ranker_path = Path(ranker_path)
         if os.path.exists(ranker_path / "config.json"):
@@ -134,26 +155,36 @@ class Blender:
             setattr(self.ranker_config, k, v)
         if ranker_config.model_name is None:
             ranker_config.model_name = str(ranker_path)
-    
-        # for other rms    
+
+        # for other rms
         if ranker_config.ranker_type not in ["pairranker", "summareranker", "simcls"]:
             # tell from the ranker_path
-            if ranker_config.model_name.endswith("OpenAssistant/reward-model-deberta-v3-large-v2"):
+            if ranker_config.model_name.endswith(
+                "OpenAssistant/reward-model-deberta-v3-large-v2"
+            ):
                 ranker_config.ranker_type = "deberta-rm"
                 ranker_config.model_type = "deberta-rm"
-            elif ranker_config.model_name.endswith("berkeley-nest/Starling-RM-7B-alpha"):
+            elif ranker_config.model_name.endswith(
+                "berkeley-nest/Starling-RM-7B-alpha"
+            ):
                 ranker_config.ranker_type = "starling-rm"
                 ranker_config.model_type = "starling-rm"
             elif ranker_config.model_name.endswith("openbmb/UltraRM-13b"):
                 ranker_config.ranker_type = "ultra-rm"
                 ranker_config.model_type = "ultra-rm"
             else:
-                raise ValueError(f"reward model type {ranker_config.model_name} not supported")
+                raise ValueError(
+                    f"reward model type {ranker_config.model_name} not supported"
+                )
             ranker_config.load_checkpoint = None
-            
-        self.ranker_config.device = device or self.ranker_config.device or self.blender_config.device
-    
-        self.ranker, self.ranker_tokenizer, self.ranker_collator = load_ranker(ranker_config)
+
+        self.ranker_config.device = (
+            device or self.ranker_config.device or self.blender_config.device
+        )
+
+        self.ranker, self.ranker_tokenizer, self.ranker_collator = load_ranker(
+            ranker_config
+        )
         device = self.ranker_config.device
         if device in ["cuda", "mps"] and ranker_config.fp16:
             self.ranker = self.ranker.half()
@@ -162,36 +193,38 @@ class Blender:
         self.ranker = self.ranker.to(device)
         self.ranker.eval()
         print("Successfully loaded ranker from ", ranker_path)
-        
-    def loadfuser(self, fuser_path:str, device:str=None, **kwargs):
+
+    def loadfuser(self, fuser_path: str, device: str = None, **kwargs):
         """Load fuser from a path
 
         Args:
-            fuser_path (str): 
+            fuser_path (str):
                 - Huggingface model path, e.g. "llm-blender/gen-fuser"
                 - Local path, e.g. "/path/to/fuser"
-            device (str): 
+            device (str):
                 cuda or cpu or None. If None, will use self.blender_config.device
-            kwargs: 
+            kwargs:
                 kwargs for GenFuserConfig
         """
         self.fuser_config = GenFuserConfig()
         self.fuser_config.model_name = fuser_path
         for k, v in kwargs.items():
             setattr(self.fuser_config, k, v)
-        self.fuser_config.device = device or self.fuser_config.device or self.blender_config.device
+        self.fuser_config.device = (
+            device or self.fuser_config.device or self.blender_config.device
+        )
         self.fuser, self.fuser_tokenizer = load_fuser(self.fuser_config)
         self.fuser.eval()
-    
+
     def rank(
-        self, 
-        inputs:List[str], 
-        candidates:List[List[str]], 
-        instructions:List[str]=None, 
-        return_scores:bool=False,
-        batch_size:int=8,
-        disable_tqdm:bool=False,
-        **rank_kwargs
+        self,
+        inputs: List[str],
+        candidates: List[List[str]],
+        instructions: List[str] = None,
+        return_scores: bool = False,
+        batch_size: int = 8,
+        disable_tqdm: bool = False,
+        **rank_kwargs,
     ):
         """Rank candidates for each input
         Args:
@@ -203,37 +236,63 @@ class Blender:
             rank_kwargs: kwargs for ranker, e.g. source_max_length, candidate_max_length
         Returns:
             ranks List[List[int]]: Ranks of candidates for each input. Lower is better. ranks[i][j] is the rank of the j-th candidate for the i-th input
-            or 
+            or
             scores List[List[float]]: Scores of candidates for each input. Higher is better. scores[i][j] is the score of the j-th candidate for the i-th input
         """
         if self.ranker is None:
-            logging.warning("No ranker loaded, please load ranker first through load_ranker()")
+            logging.warning(
+                "No ranker loaded, please load ranker first through load_ranker()"
+            )
             return None
-        assert len(inputs) == len(candidates), "Number of inputs and candidates must be the same"
-        assert all([len(c) > 0 for c in candidates]), "Each input must have at least one candidate"
-        assert all([len(c) == len(candidates[0]) for c in candidates]), "Number of candidates for each input must be the same"
+        assert len(inputs) == len(candidates), (
+            "Number of inputs and candidates must be the same"
+        )
+        assert all([len(c) > 0 for c in candidates]), (
+            "Each input must have at least one candidate"
+        )
+        assert all([len(c) == len(candidates[0]) for c in candidates]), (
+            "Number of candidates for each input must be the same"
+        )
         collate_fn = copy.copy(self.ranker_collator)
-        collate_fn.source_maxlength = rank_kwargs.get("source_max_length", None) or self.ranker_config.source_maxlength
-        collate_fn.candidate_maxlength = rank_kwargs.get("candidate_max_length", None) or self.ranker_config.candidate_maxlength
+        collate_fn.source_maxlength = (
+            rank_kwargs.get("source_max_length", None)
+            or self.ranker_config.source_maxlength
+        )
+        collate_fn.candidate_maxlength = (
+            rank_kwargs.get("candidate_max_length", None)
+            or self.ranker_config.candidate_maxlength
+        )
         dataset = RankerDataset(inputs, candidates, instructions=instructions)
-        dataloader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=False, collate_fn=collate_fn)
+        dataloader = torch.utils.data.DataLoader(
+            dataset, batch_size=batch_size, shuffle=False, collate_fn=collate_fn
+        )
         scores = []
         with torch.no_grad():
-            for batch in tqdm(iter(dataloader), desc="Ranking candidates", disable=(not self.blender_config.use_tqdm or disable_tqdm)):
-                batch = {k: v.to(self.ranker_config.device) for k, v in batch.items() if v is not None}
+            for batch in tqdm(
+                iter(dataloader),
+                desc="Ranking candidates",
+                disable=(not self.blender_config.use_tqdm or disable_tqdm),
+            ):
+                batch = {
+                    k: v.to(self.ranker_config.device)
+                    for k, v in batch.items()
+                    if v is not None
+                }
                 if self.ranker_config.ranker_type == "pairranker":
                     outputs = self.ranker._full_predict(**batch)
-                    preds = outputs['logits'].detach().cpu().numpy()
+                    preds = outputs["logits"].detach().cpu().numpy()
                     batch_scores = get_scores_from_cmps(preds)
                 elif self.ranker_config.ranker_type in ["summareranker", "simcls"]:
                     outputs = self.ranker(**batch)
-                    batch_scores = outputs['logits'].detach().cpu().numpy()
+                    batch_scores = outputs["logits"].detach().cpu().numpy()
                 elif self.ranker_config.ranker_type in ["deberta-rm"]:
                     outputs = self.ranker(**batch)
                     batch_scores = outputs.logits.detach().cpu().numpy()
-                    batch_scores = batch_scores.squeeze(-1).reshape(-1, len(candidates[0]))
+                    batch_scores = batch_scores.squeeze(-1).reshape(
+                        -1, len(candidates[0])
+                    )
                 else:
-                    outputs = self.ranker(**batch) # outputs is a list of scores
+                    outputs = self.ranker(**batch)  # outputs is a list of scores
                     batch_scores = outputs.detach().cpu().numpy()
                     batch_scores = batch_scores.reshape(-1, len(candidates[0]))
                 scores.append(batch_scores)
@@ -242,17 +301,17 @@ class Blender:
             return scores
         else:
             return get_ranks_from_scores(scores)
-    
+
     def rank_with_ref(
-        self, 
-        inputs:List[str], 
-        candidates:List[List[str]], 
-        instructions:List[str]=None, 
-        return_scores:bool=False,
-        batch_size:int=8,
-        ref_mode:str="longest",
-        ref_candidates:List[str]=None,
-        **rank_kwargs
+        self,
+        inputs: List[str],
+        candidates: List[List[str]],
+        instructions: List[str] = None,
+        return_scores: bool = False,
+        batch_size: int = 8,
+        ref_mode: str = "longest",
+        ref_candidates: List[str] = None,
+        **rank_kwargs,
     ):
         """Rank candidates for each input with reference candidates
         Args:
@@ -261,7 +320,7 @@ class Blender:
             instructions List[str]: List of instructions. if not None, will be prepended to the corresponding input
             return_scores bool: If True, will return scores instead of ranks
             batch_size int: batch size for ranking
-            ref_mode str: 
+            ref_mode str:
                 "longest" or "shortest" or "median_length" or "first" or "last"
                 If "longest", will use the longest reference candidate for each input
                 If "shortest", will use the shortest reference candidate for each input
@@ -272,17 +331,24 @@ class Blender:
             rank_kwargs: kwargs for ranker, e.g. source_max_length, candidate_max_length
         Returns:
             ranks List[List[int]]: Ranks of candidates for each input. Lower is better. ranks[i][j] is the rank of the j-th candidate for the i-th input
-            or 
+            or
             scores List[List[float]]: Scores of candidates for each input. Higher is better. scores[i][j] is the score of the j-th candidate for the i-th input
         """
-        
+
         if ref_candidates is None:
             if ref_mode == "longest":
-                ref_candidates = [max(_candidates, key=len) for _candidates in candidates]
+                ref_candidates = [
+                    max(_candidates, key=len) for _candidates in candidates
+                ]
             elif ref_mode == "shortest":
-                ref_candidates = [min(_candidates, key=len) for _candidates in candidates]
+                ref_candidates = [
+                    min(_candidates, key=len) for _candidates in candidates
+                ]
             elif ref_mode == "median_length":
-                ref_candidates = [sorted(_candidates, key=len)[len(_candidates)//2] for _candidates in candidates]
+                ref_candidates = [
+                    sorted(_candidates, key=len)[len(_candidates) // 2]
+                    for _candidates in candidates
+                ]
             elif ref_mode == "first":
                 ref_candidates = [x[0] for x in candidates]
             elif ref_mode == "last":
@@ -290,22 +356,45 @@ class Blender:
             else:
                 raise ValueError(f"Unknown ref_mode: {ref_mode}")
         else:
-            assert len(ref_candidates) == len(inputs), "Number of ref_candidates must be the same as inputs"
-            assert all([isinstance(x, str) for x in ref_candidates]), "Each ref_candidate must be a string"
-        
+            assert len(ref_candidates) == len(inputs), (
+                "Number of ref_candidates must be the same as inputs"
+            )
+            assert all([isinstance(x, str) for x in ref_candidates]), (
+                "Each ref_candidate must be a string"
+            )
+
         num_candidates_per_input = len(candidates[0])
-        assert all([len(c) == num_candidates_per_input for c in candidates]), "Number of candidates for each input must be the same"
+        assert all([len(c) == num_candidates_per_input for c in candidates]), (
+            "Number of candidates for each input must be the same"
+        )
 
         logits = np.zeros((len(inputs), num_candidates_per_input))
-        with tqdm(total=len(inputs) * num_candidates_per_input, desc="Ranking with referencie for candidates", disable=not self.blender_config.use_tqdm) as pbar:
+        with tqdm(
+            total=len(inputs) * num_candidates_per_input,
+            desc="Ranking with referencie for candidates",
+            disable=not self.blender_config.use_tqdm,
+        ) as pbar:
             for j in range(num_candidates_per_input):
                 for i in range(0, len(candidates), batch_size):
-                    batch_candidates = [x[j] for x in candidates[i:i+batch_size]]
-                    batch_ref_candidates = ref_candidates[i:i+batch_size]
-                    batch_inputs = inputs[i:i+batch_size]
-                    batch_instructions = instructions[i:i+batch_size] if instructions is not None else None
-                    batch_logits = self.compare(batch_inputs, batch_ref_candidates, batch_candidates, instructions=batch_instructions, batch_size=batch_size, return_logits=True, **rank_kwargs, disable_tqdm=True)
-                    logits[i:i+batch_size, j] = batch_logits
+                    batch_candidates = [x[j] for x in candidates[i : i + batch_size]]
+                    batch_ref_candidates = ref_candidates[i : i + batch_size]
+                    batch_inputs = inputs[i : i + batch_size]
+                    batch_instructions = (
+                        instructions[i : i + batch_size]
+                        if instructions is not None
+                        else None
+                    )
+                    batch_logits = self.compare(
+                        batch_inputs,
+                        batch_ref_candidates,
+                        batch_candidates,
+                        instructions=batch_instructions,
+                        batch_size=batch_size,
+                        return_logits=True,
+                        **rank_kwargs,
+                        disable_tqdm=True,
+                    )
+                    logits[i : i + batch_size, j] = batch_logits
                     pbar.update(len(batch_candidates))
         scores = -logits
         if return_scores:
@@ -313,14 +402,14 @@ class Blender:
         else:
             ranks = get_ranks_from_scores(scores)
             return ranks
-    
+
     def compare_conversations(
         self,
-        conversations_a:List[List[dict]],
-        conversations_b:List[List[dict]],
-        batch_size:int=4,
-        return_logits:bool=False,
-        mode:str="[A,B]+[B,A]"
+        conversations_a: List[List[dict]],
+        conversations_b: List[List[dict]],
+        batch_size: int = 4,
+        return_logits: bool = False,
+        mode: str = "[A,B]+[B,A]",
     ):
         """Compare two conversations by takeing USER turns as inputs and ASSISTANT turns as candidates
             Multi-turn conversations comparison is also supportted.
@@ -345,11 +434,11 @@ class Blender:
             return_logits (bool, optional): If True, will return logits instead of comparison results as bool. Defaults to False.
             mode: Control the compare mode, mianly deal with the effects of position bias if the model is pairwise scoring model.
                 For typical reward models that do individual scoring, this mode makes no difference.
-                - "[A,B]": 
-                    concat A (left) and B (right) as the input. 
+                - "[A,B]":
+                    concat A (left) and B (right) as the input.
                 - "[B,A]"
                     concat B (left) and A (right) as the input.
-                - "[A,B]+[B,A]": 
+                - "[A,B]+[B,A]":
                     1. concat A (left) and B (right) as the input for the first-time scoring.
                     2. concat B (left) and A (right) as the input for the second-time scoring.
                     3. The comparison result is the average of the two scoring results.
@@ -359,41 +448,72 @@ class Blender:
         # check role correctness
         for c in conversations_a + conversations_b:
             assert len(c) % 2 == 0, "Each conversation must have even number of turns"
-            assert all([c[i]['role'] == 'USER' for i in range(0, len(c), 2)]), "Each even turn must be USER"
-            assert all([c[i]['role'] == 'ASSISTANT' for i in range(1, len(c), 2)]), "Each odd turn must be ASSISTANT"
+            assert all([c[i]["role"] == "USER" for i in range(0, len(c), 2)]), (
+                "Each even turn must be USER"
+            )
+            assert all([c[i]["role"] == "ASSISTANT" for i in range(1, len(c), 2)]), (
+                "Each odd turn must be ASSISTANT"
+            )
         # check conversations correctness
-        assert len(conversations_a) == len(conversations_b), "Number of conversations must be the same"
+        assert len(conversations_a) == len(conversations_b), (
+            "Number of conversations must be the same"
+        )
         for c_a, c_b in zip(conversations_a, conversations_b):
-            assert len(c_a) == len(c_b), "Number of turns in each conversation must be the same"
-            assert all([c_a[i]['content'] == c_b[i]['content'] for i in range(0, len(c_a), 2)]), "USER turns must be the same"
-        
-        instructions = ["Finish the following coversation in each i-th turn by filling in <Response i> with your response."] * len(conversations_a)
+            assert len(c_a) == len(c_b), (
+                "Number of turns in each conversation must be the same"
+            )
+            assert all(
+                [c_a[i]["content"] == c_b[i]["content"] for i in range(0, len(c_a), 2)]
+            ), "USER turns must be the same"
+
+        instructions = [
+            "Finish the following coversation in each i-th turn by filling in <Response i> with your response."
+        ] * len(conversations_a)
         inputs = [
-            "\n".join([
-                "USER: " + x[i]['content'] +
-                f"\nAssistant: <Response {i//2+1}>" for i in range(0, len(x), 2)
-            ]) for x in conversations_a
+            "\n".join(
+                [
+                    "USER: " + x[i]["content"] + f"\nAssistant: <Response {i // 2 + 1}>"
+                    for i in range(0, len(x), 2)
+                ]
+            )
+            for x in conversations_a
         ]
         cand1_texts = [
-            "\n".join([
-                f"<Response {i//2+1}>: " + x[i]['content'] for i in range(1, len(x), 2)
-            ]) for x in conversations_a
+            "\n".join(
+                [
+                    f"<Response {i // 2 + 1}>: " + x[i]["content"]
+                    for i in range(1, len(x), 2)
+                ]
+            )
+            for x in conversations_a
         ]
         cand2_texts = [
-            "\n".join([
-                f"<Response {i//2+1}>: " + x[i]['content'] for i in range(1, len(x), 2)
-            ]) for x in conversations_b
+            "\n".join(
+                [
+                    f"<Response {i // 2 + 1}>: " + x[i]["content"]
+                    for i in range(1, len(x), 2)
+                ]
+            )
+            for x in conversations_b
         ]
-        return self.compare(inputs, cand1_texts, cand2_texts, instructions, batch_size=batch_size, return_logits=return_logits, mode=mode)
-    
+        return self.compare(
+            inputs,
+            cand1_texts,
+            cand2_texts,
+            instructions,
+            batch_size=batch_size,
+            return_logits=return_logits,
+            mode=mode,
+        )
+
     def get_best_of_n(
-        self, 
-        inputs:List[str], 
-        candidates:List[List[str]], 
-        instructions:List[str]=None,
-        pairrm_cmp_type:str="bubble",
-        return_all:bool=False,
-        batch_size:int=8,
+        self,
+        inputs: List[str],
+        candidates: List[List[str]],
+        instructions: List[str] = None,
+        pairrm_cmp_type: str = "bubble",
+        return_all: bool = False,
+        batch_size: int = 8,
     ):
         """Get the best of n candidates for each input using the ranker
         Args:
@@ -403,7 +523,7 @@ class Blender:
             pairrm_cmp_type str: one of ['bubble', 'full']
                 - 'bubble': use a single run of bubble sort to get the best of n for quicker speed. Time complexity: O(n)
                 - 'full': use full pairwise comparison matrix to get the best of n. Time complexity: O(n^2)
-            return_all bool: 
+            return_all bool:
                 If True, will return all candidates instead of the best of n candidates
                 The returned candidates will be sorted by the ranker, where the first candidate is the best
             batch_size int: batch size for ranking
@@ -419,52 +539,75 @@ class Blender:
             else:
                 best_candidates = candidates
             return best_candidates
-        if self.ranker_config.ranker_type == "pairranker" and pairrm_cmp_type == "bubble":
+        if (
+            self.ranker_config.ranker_type == "pairranker"
+            and pairrm_cmp_type == "bubble"
+        ):
             # use bubble sort single run to get the best of n for quicker speed
             collate_fn = copy.copy(self.ranker_collator)
             dataset = RankerDataset(inputs, candidates, instructions=instructions)
-            dataloader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=False, collate_fn=collate_fn)
+            dataloader = torch.utils.data.DataLoader(
+                dataset, batch_size=batch_size, shuffle=False, collate_fn=collate_fn
+            )
             best_idxs = []
             rest_idxs = []
             with torch.no_grad():
-                for batch in tqdm(iter(dataloader), desc="Ranking candidates", disable=not self.blender_config.use_tqdm):
-                    batch = {k: v.to(self.ranker_config.device) for k, v in batch.items() if v is not None}
+                for batch in tqdm(
+                    iter(dataloader),
+                    desc="Ranking candidates",
+                    disable=not self.blender_config.use_tqdm,
+                ):
+                    batch = {
+                        k: v.to(self.ranker_config.device)
+                        for k, v in batch.items()
+                        if v is not None
+                    }
                     outputs = self.ranker._bubble_predict(**batch)
-                    select_process = outputs['select_process'].detach().cpu().numpy()
+                    select_process = outputs["select_process"].detach().cpu().numpy()
                     best_idx = select_process[:, 2, -1]
                     rest_idx = np.where(
-                        select_process[:, 0, :] == select_process[:, 2, :], 
+                        select_process[:, 0, :] == select_process[:, 2, :],
                         select_process[:, 1, :],
-                        select_process[:, 0, :]
+                        select_process[:, 0, :],
                     )
                     rest_idxs.append(rest_idx)
                     best_idxs.append(best_idx)
             best_idxs = np.concatenate(best_idxs, axis=0)
             if not return_all:
-                best_candidates = np.array(candidates)[np.arange(len(candidates)), best_idxs].tolist()
+                best_candidates = np.array(candidates)[
+                    np.arange(len(candidates)), best_idxs
+                ].tolist()
             else:
                 rest_idxs = np.concatenate(rest_idxs, axis=0)
-                all_idxes = np.concatenate([best_idxs.reshape(-1, 1), rest_idxs], axis=1)
+                all_idxes = np.concatenate(
+                    [best_idxs.reshape(-1, 1), rest_idxs], axis=1
+                )
                 best_candidates = []
                 for i in range(len(candidates)):
                     best_candidates.append([candidates[i][x] for x in all_idxes[i]])
         else:
-            ranks = self.rank(inputs, candidates, instructions=instructions, batch_size=batch_size)
+            ranks = self.rank(
+                inputs, candidates, instructions=instructions, batch_size=batch_size
+            )
             if not return_all:
-                best_candidates = get_topk_candidates_from_ranks(ranks, candidates, top_k=1)
+                best_candidates = get_topk_candidates_from_ranks(
+                    ranks, candidates, top_k=1
+                )
                 best_candidates = [x[0] for x in best_candidates]
             else:
-                best_candidates = get_topk_candidates_from_ranks(ranks, candidates, top_k=None)
+                best_candidates = get_topk_candidates_from_ranks(
+                    ranks, candidates, top_k=None
+                )
         return best_candidates
-    
+
     def get_worst_of_n(
-        self, 
-        inputs:List[str], 
-        candidates:List[List[str]], 
-        instructions:List[str]=None,
-        pairrm_cmp_type:str="bubble",
-        return_all:bool=False,
-        batch_size:int=8,
+        self,
+        inputs: List[str],
+        candidates: List[List[str]],
+        instructions: List[str] = None,
+        pairrm_cmp_type: str = "bubble",
+        return_all: bool = False,
+        batch_size: int = 8,
     ):
         """Get the worst of n candidates for each input using the ranker
         Args:
@@ -474,7 +617,7 @@ class Blender:
             pairrm_cmp_type str: one of ['bubble', 'full']
                 - 'bubble': use a single run of bubble sort to get the worst of n for quicker speed. Time complexity: O(n)
                 - 'full': use full pairwise comparison matrix to get the worst of n. Time complexity: O(n^2)
-            return_all bool: 
+            return_all bool:
                 If True, will return all candidates instead of the worst of n candidates
                 The returned candidates will be sorted by the ranker, where the first candidate is the worst
             batch_size int: batch size for ranking
@@ -490,55 +633,80 @@ class Blender:
             else:
                 worst_candidates = candidates
             return worst_candidates
-        if self.ranker_config.ranker_type == "pairranker" and pairrm_cmp_type == "bubble":
+        if (
+            self.ranker_config.ranker_type == "pairranker"
+            and pairrm_cmp_type == "bubble"
+        ):
             # use bubble sort single run to get the worst of n for quicker speed
             collate_fn = copy.copy(self.ranker_collator)
             dataset = RankerDataset(inputs, candidates, instructions=instructions)
-            dataloader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=False, collate_fn=collate_fn)
+            dataloader = torch.utils.data.DataLoader(
+                dataset, batch_size=batch_size, shuffle=False, collate_fn=collate_fn
+            )
             worst_idxs = []
             rest_idxs = []
             with torch.no_grad():
-                for batch in tqdm(iter(dataloader), desc="Ranking candidates", disable=not self.blender_config.use_tqdm):
-                    batch = {k: v.to(self.ranker_config.device) for k, v in batch.items() if v is not None}
-                    outputs = self.ranker._bubble_predict(**batch, best_or_worst="worst")
-                    select_process = outputs['select_process'].detach().cpu().numpy()
+                for batch in tqdm(
+                    iter(dataloader),
+                    desc="Ranking candidates",
+                    disable=not self.blender_config.use_tqdm,
+                ):
+                    batch = {
+                        k: v.to(self.ranker_config.device)
+                        for k, v in batch.items()
+                        if v is not None
+                    }
+                    outputs = self.ranker._bubble_predict(
+                        **batch, best_or_worst="worst"
+                    )
+                    select_process = outputs["select_process"].detach().cpu().numpy()
                     worst_idx = select_process[:, 2, -1]
                     rest_idx = np.where(
-                        select_process[:, 0, :] == select_process[:, 2, :], 
+                        select_process[:, 0, :] == select_process[:, 2, :],
                         select_process[:, 1, :],
-                        select_process[:, 0, :]
+                        select_process[:, 0, :],
                     )
                     rest_idxs.append(rest_idx)
                     worst_idxs.append(worst_idx)
             worst_idxs = np.concatenate(worst_idxs, axis=0)
             if not return_all:
-                worst_candidates = np.array(candidates)[np.arange(len(candidates)), worst_idxs].tolist()
+                worst_candidates = np.array(candidates)[
+                    np.arange(len(candidates)), worst_idxs
+                ].tolist()
             else:
                 rest_idxs = np.concatenate(rest_idxs, axis=0)
-                all_idxes = np.concatenate([worst_idxs.reshape(-1, 1), rest_idxs], axis=1)
+                all_idxes = np.concatenate(
+                    [worst_idxs.reshape(-1, 1), rest_idxs], axis=1
+                )
                 worst_candidates = []
                 for i in range(len(candidates)):
                     worst_candidates.append([candidates[i][x] for x in all_idxes[i]])
         else:
-            ranks = self.rank(inputs, candidates, instructions=instructions, batch_size=batch_size)
+            ranks = self.rank(
+                inputs, candidates, instructions=instructions, batch_size=batch_size
+            )
             ranks = -ranks
             if not return_all:
-                worst_candidates = get_topk_candidates_from_ranks(ranks, candidates, top_k=1)
+                worst_candidates = get_topk_candidates_from_ranks(
+                    ranks, candidates, top_k=1
+                )
                 worst_candidates = [x[0] for x in worst_candidates]
             else:
-                worst_candidates = get_topk_candidates_from_ranks(ranks, candidates, top_k=None)
+                worst_candidates = get_topk_candidates_from_ranks(
+                    ranks, candidates, top_k=None
+                )
         return worst_candidates
-    
-    
-    def compare(self, 
-        inputs: List[str], 
-        candidates_A: List[str], 
-        candidates_B:List[str], 
-        instructions:List[str]=None, 
-        batch_size:int=4,
-        return_logits:bool=False,
-        mode:str="[A,B]+[B,A]",
-        disable_tqdm:bool=False
+
+    def compare(
+        self,
+        inputs: List[str],
+        candidates_A: List[str],
+        candidates_B: List[str],
+        instructions: List[str] = None,
+        batch_size: int = 4,
+        return_logits: bool = False,
+        mode: str = "[A,B]+[B,A]",
+        disable_tqdm: bool = False,
     ):
         """Compare candidates for each input
         Args:
@@ -548,60 +716,102 @@ class Blender:
             instructions: List of instruction strings. if not None, will be prepended to the corresponding input
             batch_size: Batch size
             return_logits: If True, will return logits instead of comparison results as bool
-            mode: 
+            mode:
                 Control the compare mode, mianly deal with the effects of position bias if the model is pairwise scoring model.
                 For typical reward models that do individual scoring, this mode makes no difference.
-                - "[A,B]": 
-                    concat A (left) and B (right) as the input. 
+                - "[A,B]":
+                    concat A (left) and B (right) as the input.
                 - "[B,A]"
                     concat B (left) and A (right) as the input.
-                - "[A,B]+[B,A]": 
+                - "[A,B]+[B,A]":
                     1. concat A (left) and B (right) as the input for the first-time scoring.
                     2. concat B (left) and A (right) as the input for the second-time scoring.
                     3. The comparison result is the average of the two scoring results.
                     The comparison result is always consistent with the order of candidates
                 "[A,B]+[B,A]" is recommended for pairwise scoring models.
         Return:
-            comparison_results: 
-                - List[float], logits as confidence that A is better than B. 
+            comparison_results:
+                - List[float], logits as confidence that A is better than B.
                     >0 means A is better than B, <0 means B is better than A
                 - List[bool], True if A is better than B, False otherwise
-            """
+        """
         if self.ranker is None:
-            logging.warning("No ranker loaded, please load ranker first through load_ranker()")
+            logging.warning(
+                "No ranker loaded, please load ranker first through load_ranker()"
+            )
             return None
-        assert len(candidates_A) == len(candidates_B), "Number of candidates_A and candidates_B must be the same"
-        assert len(inputs) == len(candidates_A), "Number of inputs and candidates must be the same"
+        assert len(candidates_A) == len(candidates_B), (
+            "Number of candidates_A and candidates_B must be the same"
+        )
+        assert len(inputs) == len(candidates_A), (
+            "Number of inputs and candidates must be the same"
+        )
         candidates = [[a, b] for a, b in zip(candidates_A, candidates_B)]
-        
-        if mode in ["[A,B]", "[B,A]"] and self.ranker_config.ranker_type == "pairranker":
+
+        if (
+            mode in ["[A,B]", "[B,A]"]
+            and self.ranker_config.ranker_type == "pairranker"
+        ):
             if mode == "[B,A]":
                 candidates = [[b, a] for a, b in zip(candidates_A, candidates_B)]
             collate_fn = copy.copy(self.ranker_collator)
             dataset = RankerDataset(inputs, candidates, instructions=instructions)
-            dataloader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=False, collate_fn=collate_fn)
+            dataloader = torch.utils.data.DataLoader(
+                dataset, batch_size=batch_size, shuffle=False, collate_fn=collate_fn
+            )
             cmp_results = []
             with torch.no_grad():
-                for batch in tqdm(iter(dataloader), desc="Ranking candidates", disable=(not self.blender_config.use_tqdm or disable_tqdm)):
-                    batch = {k: v.to(self.ranker_config.device) for k, v in batch.items() if v is not None}
-                    source_ids, source_attention_mask = batch['source_ids'], batch['source_attention_mask']
-                    left_cand_ids, left_cand_attention_mask = batch['candidate_ids'][:, 0], batch['candidate_attention_mask'][:, 0]
-                    right_cand_ids, right_cand_attention_mask = batch['candidate_ids'][:, 1], batch['candidate_attention_mask'][:, 1]
-                    if batch.get('scores', None) is None:
+                for batch in tqdm(
+                    iter(dataloader),
+                    desc="Ranking candidates",
+                    disable=(not self.blender_config.use_tqdm or disable_tqdm),
+                ):
+                    batch = {
+                        k: v.to(self.ranker_config.device)
+                        for k, v in batch.items()
+                        if v is not None
+                    }
+                    source_ids, source_attention_mask = (
+                        batch["source_ids"],
+                        batch["source_attention_mask"],
+                    )
+                    left_cand_ids, left_cand_attention_mask = (
+                        batch["candidate_ids"][:, 0],
+                        batch["candidate_attention_mask"][:, 0],
+                    )
+                    right_cand_ids, right_cand_attention_mask = (
+                        batch["candidate_ids"][:, 1],
+                        batch["candidate_attention_mask"][:, 1],
+                    )
+                    if batch.get("scores", None) is None:
                         left_scores, right_scores = None, None
                     else:
-                        left_scores, right_scores = batch['scores'][:, 0], batch['scores'][:, 1]
+                        left_scores, right_scores = (
+                            batch["scores"][:, 0],
+                            batch["scores"][:, 1],
+                        )
                     outputs = self.ranker._forward(
-                        source_ids, source_attention_mask,
-                        left_cand_ids, left_cand_attention_mask,
-                        right_cand_ids, right_cand_attention_mask,
-                        left_scores, right_scores,
+                        source_ids,
+                        source_attention_mask,
+                        left_cand_ids,
+                        left_cand_attention_mask,
+                        right_cand_ids,
+                        right_cand_attention_mask,
+                        left_scores,
+                        right_scores,
                     )
-                    cmp_results.append(outputs['logits'].detach().cpu().numpy())
+                    cmp_results.append(outputs["logits"].detach().cpu().numpy())
             cmp_results = np.concatenate(cmp_results, axis=0)
         else:
             # other ranker type, simple rank
-            scores = self.rank(inputs, candidates, return_scores=True, instructions=instructions, batch_size=batch_size, disable_tqdm=disable_tqdm)
+            scores = self.rank(
+                inputs,
+                candidates,
+                return_scores=True,
+                instructions=instructions,
+                batch_size=batch_size,
+                disable_tqdm=disable_tqdm,
+            )
             cmp_results = scores[:, 0] - scores[:, 1]
         if return_logits:
             return cmp_results
@@ -609,12 +819,12 @@ class Blender:
             return cmp_results > 0
 
     def fuse(
-        self, 
-        inputs:List[str], 
-        candidates:List[List[str]], 
-        instructions:List[str]=None, 
-        batch_size:int=4,
-        **generate_kwargs
+        self,
+        inputs: List[str],
+        candidates: List[List[str]],
+        instructions: List[str] = None,
+        batch_size: int = 4,
+        **generate_kwargs,
     ):
         """Fuse candidates for each input
         Args:
@@ -626,15 +836,27 @@ class Blender:
             outputs List[str]: Fused outputs for each input
         """
         if self.fuser is None:
-            logging.warning("No fuser loaded, please load fuser first through load_fuser()")
+            logging.warning(
+                "No fuser loaded, please load fuser first through load_fuser()"
+            )
             return None
         generate_kwargs = generate_kwargs.copy()
-        candidate_maxlength = generate_kwargs.pop("candidate_max_length", None) or self.fuser_config.candidate_maxlength
-        dataset = GenFuserDataset(inputs, candidates, self.fuser_tokenizer,
-            instructions=instructions, max_length=self.fuser_config.max_length, 
-            candidate_maxlength=candidate_maxlength)
+        candidate_maxlength = (
+            generate_kwargs.pop("candidate_max_length", None)
+            or self.fuser_config.candidate_maxlength
+        )
+        dataset = GenFuserDataset(
+            inputs,
+            candidates,
+            self.fuser_tokenizer,
+            instructions=instructions,
+            max_length=self.fuser_config.max_length,
+            candidate_maxlength=candidate_maxlength,
+        )
 
-        dataloader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=False)
+        dataloader = torch.utils.data.DataLoader(
+            dataset, batch_size=batch_size, shuffle=False
+        )
         generate_params = {
             "max_new_tokens": candidate_maxlength,
             "num_beams": 4,
@@ -642,48 +864,54 @@ class Blender:
         }
         if generate_kwargs:
             generate_params.update(generate_kwargs)
-            
+
         generations = []
-        for batch in tqdm(iter(dataloader), desc="Fusing candidates", disable=not self.blender_config.use_tqdm):
+        for batch in tqdm(
+            iter(dataloader),
+            desc="Fusing candidates",
+            disable=not self.blender_config.use_tqdm,
+        ):
             batch = {k: v.to(self.fuser_config.device) for k, v in batch.items()}
-            keep_column_mask = batch['attention_mask'].ne(0).any(dim=0)
-            batch['input_ids'] = batch['input_ids'][:, keep_column_mask]
-            batch['attention_mask'] = batch['attention_mask'][:, keep_column_mask]
+            keep_column_mask = batch["attention_mask"].ne(0).any(dim=0)
+            batch["input_ids"] = batch["input_ids"][:, keep_column_mask]
+            batch["attention_mask"] = batch["attention_mask"][:, keep_column_mask]
             output_ids = self.fuser.generate(**batch, **generate_params)
-            _generations = self.fuser_tokenizer.batch_decode(output_ids, skip_special_tokens=True)
+            _generations = self.fuser_tokenizer.batch_decode(
+                output_ids, skip_special_tokens=True
+            )
             generations.extend(_generations)
         return generations
-    
+
     def n_generate(
         self,
-        model, # Union[transformers.PreTrainedModel, vllm.LLM]
-        model_tokenizer:transformers.PreTrainedTokenizer,
-        inputs:List[str],
-        instructions:List[str]=None,
-        n:int=5,
-        sampling_mode:str="top_p_sampling",
-        batch_size:int=4,
-        **generate_kwargs:dict,
+        model,  # Union[transformers.PreTrainedModel, vllm.LLM]
+        model_tokenizer: transformers.PreTrainedTokenizer,
+        inputs: List[str],
+        instructions: List[str] = None,
+        n: int = 5,
+        sampling_mode: str = "top_p_sampling",
+        batch_size: int = 4,
+        **generate_kwargs: dict,
     ):
         """We will generate n generations for each input,
 
         Args:
             model: Union[transformers.PreTrainedModel, vllm.LLM]
                 Huggingface model that could generate with .generate(**generate_kwargs)
-            model_tokenizer: 
+            model_tokenizer:
                 Huggingface tokenizer that could tokenize with .__call__(**generate_kwargs)
-            inputs List[str]: 
+            inputs List[str]:
                 List of input texts
-            instructions List[str]: 
+            instructions List[str]:
                 List of instructions. if not None, will be prepended to the corresponding input
-            n int: 
+            n int:
                 the n parameter in best-of-n. That is, how many samples to generate for ranking for each input
-            sampling_mode: 
+            sampling_mode:
                 "top_k_sampling" or "top_p_sampling"
                 if None, will use custom sampling strategy by generate_kwargs
-            batch_size int: 
+            batch_size int:
                 batch size for generation
-            generate_kwargs: 
+            generate_kwargs:
                 kwargs for model.generate()
                 recommended kwargs:
                     - max_new_tokens: max length of the generation. If not specified, will use model_tokenizer.model_max_length
@@ -691,12 +919,14 @@ class Blender:
                     - top_p: if mode is "top_p_sampling", will use this top_p. if not specified, will use 1.0
                     - temperature: temperature for sampling. if not specified, will use 0.7
                 Note that num_return_sequences will be set to n, so you don't need to specify it
-                    
+
         Returns:
             sampled_candidates
                 - List[List[str]]: All sampled candidates against the ranker for each input
         """
-        assert len(inputs) == len(instructions) if instructions is not None else True, "Number of inputs and instructions must be the same if instructions is not None"
+        assert len(inputs) == len(instructions) if instructions is not None else True, (
+            "Number of inputs and instructions must be the same if instructions is not None"
+        )
         if sampling_mode == "top_k_sampling":
             generate_kwargs["do_sample"] = True
             generate_kwargs["top_k"] = generate_kwargs.get("top_k", 50)
@@ -712,16 +942,33 @@ class Blender:
             raise ValueError(f"Unknown sampling_mode: {sampling_mode}")
         if "max_new_tokens" not in generate_kwargs:
             # limits of the generation is the default max_length of the model if max_new_tokes not specified
-            generate_kwargs['max_length'] = generate_kwargs.get("max_length", model_tokenizer.model_max_length)
+            generate_kwargs["max_length"] = generate_kwargs.get(
+                "max_length", model_tokenizer.model_max_length
+            )
         generate_kwargs["num_return_sequences"] = n
         generate_kwargs["output_scores"] = True
-        generate_kwargs['return_dict_in_generate'] = True
-        
-        prompts = [x + "\n" + y for x, y in zip(instructions, inputs)] if instructions is not None else inputs
-        sampled_candidates: List[List[str]] = [] # sampled generations for each input [bz, n]
+        generate_kwargs["return_dict_in_generate"] = True
+
+        prompts = (
+            [x + "\n" + y for x, y in zip(instructions, inputs)]
+            if instructions is not None
+            else inputs
+        )
+        sampled_candidates: List[
+            List[str]
+        ] = []  # sampled generations for each input [bz, n]
         if is_vllm_imported and isinstance(model, vllm.LLM):
             sampling_params = vllm.SamplingParams(
-                n=n, max_tokens=generate_kwargs.get("max_tokens", generate_kwargs.get("max_new_tokens", generate_kwargs.get("max_length", model_tokenizer.model_max_length))),
+                n=n,
+                max_tokens=generate_kwargs.get(
+                    "max_tokens",
+                    generate_kwargs.get(
+                        "max_new_tokens",
+                        generate_kwargs.get(
+                            "max_length", model_tokenizer.model_max_length
+                        ),
+                    ),
+                ),
             )
             for k, v in generate_kwargs.items():
                 if hasattr(sampling_params, k):
@@ -729,40 +976,55 @@ class Blender:
                     setattr(sampling_params, k, v)
             outputs = model.generate(prompts, sampling_params=sampling_params)
             for output in outputs:
-                sampled_candidates.append([output.outputs[i].text for i in range(len(output.outputs))])
+                sampled_candidates.append(
+                    [output.outputs[i].text for i in range(len(output.outputs))]
+                )
         else:
-            for i in tqdm(range(0, len(prompts), batch_size), desc="Sampling generations"):
-                bz_start, bz_end = i, min(i+batch_size, len(inputs))
-                
-                bz_prompts = prompts[bz_start: bz_end]
-                bz_encodings = model_tokenizer(bz_prompts, return_tensors="pt", padding=True, truncation=True)
+            for i in tqdm(
+                range(0, len(prompts), batch_size), desc="Sampling generations"
+            ):
+                bz_start, bz_end = i, min(i + batch_size, len(inputs))
+
+                bz_prompts = prompts[bz_start:bz_end]
+                bz_encodings = model_tokenizer(
+                    bz_prompts, return_tensors="pt", padding=True, truncation=True
+                )
                 bz_encodings = {k: v.to(model.device) for k, v in bz_encodings.items()}
                 bz_outputs = model.generate(**bz_encodings, **generate_kwargs)
                 bz_output_ids = bz_outputs.sequences
                 bz_output_scores = torch.stack(bz_outputs.scores, dim=0)
-                if bz_output_ids.shape[1] == bz_encodings['input_ids'].shape[1] + bz_output_scores.shape[0]:
+                if (
+                    bz_output_ids.shape[1]
+                    == bz_encodings["input_ids"].shape[1] + bz_output_scores.shape[0]
+                ):
                     # for decoder-only models
-                    bz_output_ids = bz_output_ids[:, bz_encodings['input_ids'].shape[1]:]
+                    bz_output_ids = bz_output_ids[
+                        :, bz_encodings["input_ids"].shape[1] :
+                    ]
                 # remove inputs part from outputs
-                bz_outputs = model_tokenizer.batch_decode(bz_output_ids, skip_special_tokens=True)
-                bz_sampled_candidates = [bz_outputs[i: i+n] for i in range(0, len(bz_outputs), n)]
+                bz_outputs = model_tokenizer.batch_decode(
+                    bz_output_ids, skip_special_tokens=True
+                )
+                bz_sampled_candidates = [
+                    bz_outputs[i : i + n] for i in range(0, len(bz_outputs), n)
+                ]
                 sampled_candidates.extend(bz_sampled_candidates)
         return sampled_candidates
 
     def best_of_n_generate(
         self,
-        model, # Union[transformers.PreTrainedModel, vllm.LLM]
-        model_tokenizer:transformers.PreTrainedTokenizer,
-        inputs:List[str],
-        instructions:List[str]=None,
-        n:int=5,
-        sampling_mode:str="top_p_sampling",
-        batch_size:int=4,
-        pairrm_cmp_type:str="bubble",
-        return_all:bool=False,
-        **generate_kwargs:dict,
+        model,  # Union[transformers.PreTrainedModel, vllm.LLM]
+        model_tokenizer: transformers.PreTrainedTokenizer,
+        inputs: List[str],
+        instructions: List[str] = None,
+        n: int = 5,
+        sampling_mode: str = "top_p_sampling",
+        batch_size: int = 4,
+        pairrm_cmp_type: str = "bubble",
+        return_all: bool = False,
+        **generate_kwargs: dict,
     ):
-        """Decoding enhance generate. 
+        """Decoding enhance generate.
             In this process, we will generate multiple generations for each input,
             Then we will rank these generations and only return the top-k generations,
             thus enhancing the quality of generations.
@@ -770,26 +1032,26 @@ class Blender:
         Args:
             model: Union[transformers.PreTrainedModel, vllm.LLM]
                 Huggingface model that could generate with .generate(**generate_kwargs)
-            model_tokenizer: 
+            model_tokenizer:
                 Huggingface tokenizer that could tokenize with .__call__(**generate_kwargs)
-            inputs List[str]: 
+            inputs List[str]:
                 List of input texts
-            instructions List[str]: 
+            instructions List[str]:
                 List of instructions. if not None, will be prepended to the corresponding input
-            n int: 
+            n int:
                 the n parameter in best-of-n. That is, how many samples to generate for ranking for each input
-            sampling_mode: 
+            sampling_mode:
                 "top_k_sampling" or "top_p_sampling"
                 if None, will use custom sampling strategy by generate_kwargs
-            batch_size int: 
+            batch_size int:
                 batch size for generation
             pairrm_cmp_type str: one of ['bubble', 'full']
                 - 'bubble': use a single run of bubble sort to get the best of n for quicker speed. Time complexity: O(n)
                 - 'full': use full pairwise comparison matrix to get the best of n. Time complexity: O(n^2)
-            return_all bool: 
+            return_all bool:
                 If True, will return all candidates instead of the best of n candidates
                 The returned candidates will be sorted by the ranker, where the first candidate is the best
-            generate_kwargs: 
+            generate_kwargs:
                 kwargs for model.generate()
                 recommended kwargs:
                     - max_new_tokens: max length of the generation. If not specified, will use model_tokenizer.model_max_length
@@ -797,21 +1059,43 @@ class Blender:
                     - top_p: if mode is "top_p_sampling", will use this top_p. if not specified, will use 1.0
                     - temperature: temperature for sampling. if not specified, will use 0.7
                 Note that num_return_sequences will be set to n, so you don't need to specify it
-                    
+
         Returns:
             best_candidates
                 - List[str]: Best candidates against the ranker for each input
                 - List[List[str]]: All candidates against the ranker for each input, when return_all is True
         """
-        sampled_candidates = self.n_generate(model, model_tokenizer, inputs, 
-            instructions=instructions, n=n, sampling_mode=sampling_mode, batch_size=batch_size, **generate_kwargs)
-        
-        best_of_n_outputs = self.get_best_of_n(inputs, sampled_candidates, 
-            instructions=instructions, batch_size=min(batch_size, 32),
-            pairrm_cmp_type=pairrm_cmp_type, return_all=return_all)
-        return best_of_n_outputs 
-    
-    def rank_and_fuse(self, inputs:List[str], candidates:List[List[str]], instructions:List[str]=None, return_scores=False, batch_size=4, top_k=3, **generate_kwargs):
+        sampled_candidates = self.n_generate(
+            model,
+            model_tokenizer,
+            inputs,
+            instructions=instructions,
+            n=n,
+            sampling_mode=sampling_mode,
+            batch_size=batch_size,
+            **generate_kwargs,
+        )
+
+        best_of_n_outputs = self.get_best_of_n(
+            inputs,
+            sampled_candidates,
+            instructions=instructions,
+            batch_size=min(batch_size, 32),
+            pairrm_cmp_type=pairrm_cmp_type,
+            return_all=return_all,
+        )
+        return best_of_n_outputs
+
+    def rank_and_fuse(
+        self,
+        inputs: List[str],
+        candidates: List[List[str]],
+        instructions: List[str] = None,
+        return_scores=False,
+        batch_size=4,
+        top_k=3,
+        **generate_kwargs,
+    ):
         """Rank the candidates using ranker and fuse the top-k candidates with genfuser
         Args:
             inputs List[str]: List of input texts
@@ -824,13 +1108,27 @@ class Blender:
             fused_generations List[str]: Fused outputs for each input
             ranks_or_scores List[List[int]]: Ranks or scores of candidates for each input. element[i][j] is the rank or score of the j-th candidate for the i-th input
         """
-        ranks_or_scores = self.rank(inputs, candidates, instructions=instructions, batch_size=batch_size, return_scores=return_scores)
+        ranks_or_scores = self.rank(
+            inputs,
+            candidates,
+            instructions=instructions,
+            batch_size=batch_size,
+            return_scores=return_scores,
+        )
         if return_scores:
             # if scores, transform to ranks. That is, from higher is better to lower is better
-            topk_candidates = get_topk_candidates_from_ranks(-ranks_or_scores, candidates, top_k=top_k)
+            topk_candidates = get_topk_candidates_from_ranks(
+                -ranks_or_scores, candidates, top_k=top_k
+            )
         else:
-            topk_candidates = get_topk_candidates_from_ranks(ranks_or_scores, candidates, top_k=top_k)
-        fused_generations = self.fuse(inputs, topk_candidates, instructions=instructions, batch_size=batch_size, **generate_kwargs)
+            topk_candidates = get_topk_candidates_from_ranks(
+                ranks_or_scores, candidates, top_k=top_k
+            )
+        fused_generations = self.fuse(
+            inputs,
+            topk_candidates,
+            instructions=instructions,
+            batch_size=batch_size,
+            **generate_kwargs,
+        )
         return fused_generations, ranks_or_scores
-
-    

--- a/llm_blender/blender/blender.py
+++ b/llm_blender/blender/blender.py
@@ -119,7 +119,7 @@ class Blender:
                     logging.warning(
                         f"Try dowloading checkpoint from huggingface hub: {ranker_path}"
                     )
-                    snapshot_download(ranker_path, local_dir=cache_dir / ranker_path)
+                    snapshot_download(ranker_path, cache_dir=cache_dir)
                     ranker_path = cache_dir / ranker_path
                     logging.warning(
                         f"Successfully downloaded checkpoint to '{ranker_path}'"

--- a/llm_blender/blender/blender_utils.py
+++ b/llm_blender/blender/blender_utils.py
@@ -1,4 +1,3 @@
-
 import os
 import torch
 import logging
@@ -13,17 +12,18 @@ from ..pair_ranker.model_util import (
 from ..pair_ranker.config import RankerConfig
 from ..gen_fuser.config import GenFuserConfig
 from transformers import (
-    AutoTokenizer, 
+    AutoTokenizer,
     AutoModelForSeq2SeqLM,
     AutoModelForSequenceClassification,
 )
 from typing import List
 from huggingface_hub import snapshot_download
-from transformers.utils.hub import TRANSFORMERS_CACHE
+from huggingface_hub.constants import HF_HOME
+
 
 def get_torch_dtype(dtype_str):
     """
-        Get the torch dtype from a string
+    Get the torch dtype from a string
     """
     if dtype_str == "float32":
         return torch.float32
@@ -36,17 +36,21 @@ def get_torch_dtype(dtype_str):
     else:
         raise ValueError("Invalid dtype {}".format(dtype_str))
 
+
 def load_other_ranker(ranker_config: RankerConfig):
     """Load Other Ranker (Reward Model) from config file
-        Currently supporting: 
-            - BERT series model, e.g. OpenAssistant/reward-model-deberta-v3-large-v2
+    Currently supporting:
+        - BERT series model, e.g. OpenAssistant/reward-model-deberta-v3-large-v2
     """
     model_name = ranker_config.model_name
     model = AutoModelForSequenceClassification.from_pretrained(
-        model_name, cache_dir=ranker_config.cache_dir,
+        model_name,
+        cache_dir=ranker_config.cache_dir,
         device_map="auto",
     )
-    tokenizer = AutoTokenizer.from_pretrained(model_name, cache_dir=ranker_config.cache_dir)
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_name, cache_dir=ranker_config.cache_dir
+    )
     collator = build_collator(
         "other",
         tokenizer,
@@ -54,13 +58,18 @@ def load_other_ranker(ranker_config: RankerConfig):
         ranker_config.candidate_maxlength,
     )
     return model, tokenizer, collator
-    
-    
+
+
 def load_ranker(ranker_config: RankerConfig):
     """Load PairRanker model from config file"""
-    tokenizer = build_tokenizer(ranker_config.model_name, cache_dir=ranker_config.cache_dir)
-    collator = build_collator(ranker_config.ranker_type, tokenizer,
-        ranker_config.source_maxlength, ranker_config.candidate_maxlength,
+    tokenizer = build_tokenizer(
+        ranker_config.model_name, cache_dir=ranker_config.cache_dir
+    )
+    collator = build_collator(
+        ranker_config.ranker_type,
+        tokenizer,
+        ranker_config.source_maxlength,
+        ranker_config.candidate_maxlength,
     )
     ranker = build_ranker(
         ranker_config.ranker_type,
@@ -76,18 +85,22 @@ def load_ranker(ranker_config: RankerConfig):
         load_checkpoint = Path(ranker_config.load_checkpoint)
         if load_checkpoint.name == "pytorch_model.bin":
             load_checkpoint = load_checkpoint.parent
-        
-        if (load_checkpoint/"pytorch_model.bin").exists():
+
+        if (load_checkpoint / "pytorch_model.bin").exists():
             # pytorch_model.bin
-            state_dict = torch.load(load_checkpoint/"pytorch_model.bin", map_location="cpu")
+            state_dict = torch.load(
+                load_checkpoint / "pytorch_model.bin", map_location="cpu"
+            )
             load_result = ranker.load_state_dict(state_dict, strict=False)
             if load_result.missing_keys:
                 logging.warning(f"Missing keys: {load_result.missing_keys}")
             else:
                 logging.info(f"Successfully loaded checkpoint from '{load_checkpoint}'")
-        elif (load_checkpoint/"model.safetensors").exists():
+        elif (load_checkpoint / "model.safetensors").exists():
             # model.safetensors
-            load_result = safetensors.torch.load_model(ranker, load_checkpoint/"model.safetensors")
+            load_result = safetensors.torch.load_model(
+                ranker, load_checkpoint / "model.safetensors"
+            )
             missing_keys, unexpected_keys = load_result
             if missing_keys:
                 logging.warning(f"Missing keys: {missing_keys}")
@@ -96,36 +109,69 @@ def load_ranker(ranker_config: RankerConfig):
             if not missing_keys and not unexpected_keys:
                 logging.info(f"Successfully loaded checkpoint from '{load_checkpoint}'")
         else:
-            raise ValueError(f"Cannot find pytorch_model.bin or model.safetensors in {load_checkpoint}")
-        
+            raise ValueError(
+                f"Cannot find pytorch_model.bin or model.safetensors in {load_checkpoint}"
+            )
+
     return ranker, tokenizer, collator
 
-def get_topk_candidates_from_ranks(ranks:List[List[int]], candidates:List[List[str]], top_k:int):
+
+def get_topk_candidates_from_ranks(
+    ranks: List[List[int]], candidates: List[List[str]], top_k: int
+):
     """Get top k candidates from a list of ranks"""
     ranks = np.array(ranks)
     sorted_idxs = np.argsort(ranks, axis=1)
     candidates = np.array(candidates)
-    topk_candidates = candidates[np.arange(len(candidates))[:, None], sorted_idxs[:, :top_k]]
+    topk_candidates = candidates[
+        np.arange(len(candidates))[:, None], sorted_idxs[:, :top_k]
+    ]
     return topk_candidates
+
 
 def load_fuser(fuser_config: GenFuserConfig):
     model_name = fuser_config.model_name
-    tokenizer = AutoTokenizer.from_pretrained(model_name, cache_dir=fuser_config.cache_dir)
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_name, cache_dir=fuser_config.cache_dir
+    )
+
+    # Build quantization config for v5 compatibility
+    quantization_config = None
+    if fuser_config.load_in_4bit or fuser_config.load_in_8bit:
+        from transformers import BitsAndBytesConfig
+
+        quantization_config = BitsAndBytesConfig(
+            load_in_4bit=fuser_config.load_in_4bit,
+            load_in_8bit=fuser_config.load_in_8bit,
+        )
+
     if fuser_config.device == "cpu":
         fuser = AutoModelForSeq2SeqLM.from_pretrained(
-            model_name, cache_dir=fuser_config.cache_dir,
-            device_map={"": "cpu"}, torch_dtype=get_torch_dtype(fuser_config.torch_dtype),
+            model_name,
+            cache_dir=fuser_config.cache_dir,
+            device_map={"": "cpu"},
+            torch_dtype=get_torch_dtype(fuser_config.torch_dtype),
+            quantization_config=quantization_config,
         )
     else:
         fuser = AutoModelForSeq2SeqLM.from_pretrained(
-            model_name, cache_dir=fuser_config.cache_dir,
-            device_map="auto", torch_dtype=get_torch_dtype(fuser_config.torch_dtype),
-            load_in_4bit=fuser_config.load_in_4bit, load_in_8bit=fuser_config.load_in_8bit,
+            model_name,
+            cache_dir=fuser_config.cache_dir,
+            device_map="auto",
+            torch_dtype=get_torch_dtype(fuser_config.torch_dtype),
+            quantization_config=quantization_config,
         )
     return fuser, tokenizer
 
+
 class RankerDataset(torch.utils.data.Dataset):
-    def __init__(self, inputs:List[str], candidates:List[List[str]], instructions:List[str]=None, scores=None):
+    def __init__(
+        self,
+        inputs: List[str],
+        candidates: List[List[str]],
+        instructions: List[str] = None,
+        scores=None,
+    ):
         self.instructions = instructions
         self.inputs = inputs
         self.candidates = candidates
@@ -140,28 +186,40 @@ class RankerDataset(torch.utils.data.Dataset):
         candidates = self.candidates[index]
         scores = self.scores[index] if self.scores is not None else None
         batch = {
-            'index' : index,
-            'source' : instruction + input_text,
-            'candidates' : candidates,
-            'scores' : scores,
+            "index": index,
+            "source": instruction + input_text,
+            "candidates": candidates,
+            "scores": scores,
         }
         batch = {k: v for k, v in batch.items() if v is not None}
         return batch
 
+
 class GenFuserDataset(torch.utils.data.Dataset):
-    def __init__(self, inputs:List[str], candidates:List[List[str]], tokenizer, max_length, candidate_maxlength, instructions:List[str]=None, outputs:List[str]=None):
+    def __init__(
+        self,
+        inputs: List[str],
+        candidates: List[List[str]],
+        tokenizer,
+        max_length,
+        candidate_maxlength,
+        instructions: List[str] = None,
+        outputs: List[str] = None,
+    ):
         """
-            data: list of dict
-            tokenizer: tokenizer
-            max_length: max length of the input sequence
-            top_k: number of top k candidate to select
-            select_key: selection metric for the top k candidates
+        data: list of dict
+        tokenizer: tokenizer
+        max_length: max length of the input sequence
+        top_k: number of top k candidate to select
+        select_key: selection metric for the top k candidates
         """
         self.instructions = instructions
         self.inputs = inputs
         self.candidates = candidates
         self.outputs = outputs
-        assert len(self.inputs) == len(self.candidates), "Number of inputs and candidates must be the same"
+        assert len(self.inputs) == len(self.candidates), (
+            "Number of inputs and candidates must be the same"
+        )
         self.tokenizer = tokenizer
         self.max_length = max_length
         self.candidate_maxlength = candidate_maxlength
@@ -178,16 +236,20 @@ class GenFuserDataset(torch.utils.data.Dataset):
             for i in range(len(candidates)):
                 ids = self.tokenizer.encode(candidates[i], add_special_tokens=False)
                 if len(ids) > self.candidate_maxlength:
-                    ids = ids[:self.candidate_maxlength]
+                    ids = ids[: self.candidate_maxlength]
                     candidates[i] = self.tokenizer.decode(ids)
                     candidates[i] += "..."
 
         # concatenate input and candidates
-        instruction = "Instruction: " + instruction # replace "</s>" with "</s>"
+        instruction = "Instruction: " + instruction  # replace "</s>" with "</s>"
         input = "Input: " + input_text
-        candidates = "</s>".join([f"Candidate {i}: <extra_id_{i}>:" + c for i, c in enumerate(candidates)]) # extra id
+        candidates = "</s>".join(
+            [f"Candidate {i}: <extra_id_{i}>:" + c for i, c in enumerate(candidates)]
+        )  # extra id
         fuse_input = "</s>".join([instruction, input, candidates])
-        fuse_input += "</s>Summarize candidates into a better one for the given instruction:"
+        fuse_input += (
+            "</s>Summarize candidates into a better one for the given instruction:"
+        )
 
         # tokenize
         fuse_input_ids = self.tokenizer(
@@ -196,11 +258,16 @@ class GenFuserDataset(torch.utils.data.Dataset):
             truncation=True,
             padding="max_length",
             return_tensors="pt",
-            add_special_tokens=False,)
+            add_special_tokens=False,
+        )
         fuse_input_ids = {k: v.squeeze(0) for k, v in fuse_input_ids.items()}
 
         if output is not None:
-            labels_ids = self.tokenizer.encode(output, return_tensors="pt", add_special_tokens=False,).squeeze(0)
+            labels_ids = self.tokenizer.encode(
+                output,
+                return_tensors="pt",
+                add_special_tokens=False,
+            ).squeeze(0)
         else:
             labels_ids = None
 
@@ -211,7 +278,15 @@ class GenFuserDataset(torch.utils.data.Dataset):
         batch = {k: v for k, v in batch.items() if v is not None}
         return batch
 
-def tokenize_pair(tokenizer, sources:List[str], candidate1s:List[str], candidate2s:List[str], source_max_length=1224, candidate_max_length=412):
+
+def tokenize_pair(
+    tokenizer,
+    sources: List[str],
+    candidate1s: List[str],
+    candidate2s: List[str],
+    source_max_length=1224,
+    candidate_max_length=412,
+):
     ids = []
     assert len(sources) == len(candidate1s) == len(candidate2s)
     max_length = source_max_length + 2 * candidate_max_length
@@ -219,13 +294,29 @@ def tokenize_pair(tokenizer, sources:List[str], candidate1s:List[str], candidate
     cand1_prefix = "<|candidate1|>"
     cand2_prefix = "<|candidate2|>"
     for i in range(len(sources)):
-        source_ids = tokenizer.encode(source_prefix + sources[i], max_length=source_max_length, truncation=True)
+        source_ids = tokenizer.encode(
+            source_prefix + sources[i], max_length=source_max_length, truncation=True
+        )
         candidate_max_length = (max_length - len(source_ids)) // 2
-        candidate1_ids = tokenizer.encode(cand1_prefix + candidate1s[i], max_length=candidate_max_length, truncation=True)
-        candidate2_ids = tokenizer.encode(cand2_prefix + candidate2s[i], max_length=candidate_max_length, truncation=True)
+        candidate1_ids = tokenizer.encode(
+            cand1_prefix + candidate1s[i],
+            max_length=candidate_max_length,
+            truncation=True,
+        )
+        candidate2_ids = tokenizer.encode(
+            cand2_prefix + candidate2s[i],
+            max_length=candidate_max_length,
+            truncation=True,
+        )
         ids.append(source_ids + candidate1_ids + candidate2_ids)
-    encodings = tokenizer.pad({"input_ids": ids}, return_tensors="pt", padding="max_length", max_length=max_length)
+    encodings = tokenizer.pad(
+        {"input_ids": ids},
+        return_tensors="pt",
+        padding="max_length",
+        max_length=max_length,
+    )
     return encodings
+
 
 def get_pair_from_conv(convAs: List[str], convBs: List[str]):
     """Compare two conversations by takeing USER turns as inputs and ASSISTANT turns as candidates
@@ -250,33 +341,55 @@ def get_pair_from_conv(convAs: List[str], convBs: List[str]):
     """
     for c in convAs + convBs:
         assert len(c) % 2 == 0, "Each conversation must have even number of turns"
-        assert all([c[i]['role'] == 'USER' for i in range(0, len(c), 2)]), "Each even turn must be USER"
-        assert all([c[i]['role'] == 'ASSISTANT' for i in range(1, len(c), 2)]), "Each odd turn must be ASSISTANT"
+        assert all([c[i]["role"] == "USER" for i in range(0, len(c), 2)]), (
+            "Each even turn must be USER"
+        )
+        assert all([c[i]["role"] == "ASSISTANT" for i in range(1, len(c), 2)]), (
+            "Each odd turn must be ASSISTANT"
+        )
     # check conversations correctness
     assert len(convAs) == len(convBs), "Number of conversations must be the same"
     for c_a, c_b in zip(convAs, convBs):
-        assert len(c_a) == len(c_b), "Number of turns in each conversation must be the same"
-        assert all([c_a[i]['content'] == c_b[i]['content'] for i in range(0, len(c_a), 2)]), "USER turns must be the same"
-    
-    instructions = ["Finish the following coversation in each i-th turn by filling in <Response i> with your response."] * len(convAs)
+        assert len(c_a) == len(c_b), (
+            "Number of turns in each conversation must be the same"
+        )
+        assert all(
+            [c_a[i]["content"] == c_b[i]["content"] for i in range(0, len(c_a), 2)]
+        ), "USER turns must be the same"
+
+    instructions = [
+        "Finish the following coversation in each i-th turn by filling in <Response i> with your response."
+    ] * len(convAs)
     inputs = [
-        "\n".join([
-            "USER: " + x[i]['content'] +
-            f"\nAssistant: <Response {i//2+1}>" for i in range(0, len(x), 2)
-        ]) for x in convAs
+        "\n".join(
+            [
+                "USER: " + x[i]["content"] + f"\nAssistant: <Response {i // 2 + 1}>"
+                for i in range(0, len(x), 2)
+            ]
+        )
+        for x in convAs
     ]
     cand1_texts = [
-        "\n".join([
-            f"<Response {i//2+1}>: " + x[i]['content'] for i in range(1, len(x), 2)
-        ]) for x in convAs
+        "\n".join(
+            [
+                f"<Response {i // 2 + 1}>: " + x[i]["content"]
+                for i in range(1, len(x), 2)
+            ]
+        )
+        for x in convAs
     ]
     cand2_texts = [
-        "\n".join([
-            f"<Response {i//2+1}>: " + x[i]['content'] for i in range(1, len(x), 2)
-        ]) for x in convBs
+        "\n".join(
+            [
+                f"<Response {i // 2 + 1}>: " + x[i]["content"]
+                for i in range(1, len(x), 2)
+            ]
+        )
+        for x in convBs
     ]
     inputs = [inst + inp for inst, inp in zip(instructions, inputs)]
     return inputs, cand1_texts, cand2_texts
+
 
 def tokenize_conv_pair(tokenizer, convAs: List[str], convBs: List[str]):
     """Compare two conversations by takeing USER turns as inputs and ASSISTANT turns as candidates

--- a/llm_blender/gen_fuser/ds_train.py
+++ b/llm_blender/gen_fuser/ds_train.py
@@ -3,6 +3,7 @@ Fine-tuning the library models for sequence to sequence.
 
 For now, this supports Zero3 with float32
 """
+
 import wandb
 import logging
 import os
@@ -49,17 +50,18 @@ class ModelArguments:
     """
 
     model_name_or_path: str = field(
-        metadata={"help": "Path to pretrained model or model identifier from huggingface.co/models"}
+        metadata={
+            "help": "Path to pretrained model or model identifier from huggingface.co/models"
+        }
     )
 
     cache_dir: str = field(
-        metadata={"help": "Path to pretrained model or model identifier from huggingface.co/models"}
+        metadata={
+            "help": "Path to pretrained model or model identifier from huggingface.co/models"
+        }
     )
 
-    early_stopping_patience: int = field(
-        default=-1
-    )
-
+    early_stopping_patience: int = field(default=-1)
 
 
 @dataclass
@@ -68,21 +70,23 @@ class DataTrainingArguments:
     Arguments pertaining to what data we are going to input our model for training and eval.
     """
 
-    train_file: Optional[str] = field(default=None, metadata={"help": "The input training data file (a jsonlines)."})
+    train_file: Optional[str] = field(
+        default=None, metadata={"help": "The input training data file (a jsonlines)."}
+    )
     validation_file: Optional[str] = field(
         default=None,
-        metadata={
-            "help": "An optional input evaluation data file (a jsonlines)"
-        },
+        metadata={"help": "An optional input evaluation data file (a jsonlines)"},
     )
     test_file: Optional[str] = field(
         default=None,
         metadata={
-            "help": "An optional input test data file to evaluate the metrics (rouge) on " "(a jsonlines or csv file)."
+            "help": "An optional input test data file to evaluate the metrics (rouge) on "
+            "(a jsonlines or csv file)."
         },
     )
     overwrite_cache: bool = field(
-        default=False, metadata={"help": "Overwrite the cached training and evaluation sets"}
+        default=False,
+        metadata={"help": "Overwrite the cached training and evaluation sets"},
     )
     preprocessing_num_workers: Optional[int] = field(
         default=None,
@@ -92,28 +96,28 @@ class DataTrainingArguments:
         default=1024,
         metadata={
             "help": "The maximum total input sequence length after tokenization. Sequences longer "
-                    "than this will be truncated, sequences shorter will be padded."
+            "than this will be truncated, sequences shorter will be padded."
         },
     )
     max_target_length: Optional[int] = field(
         default=128,
         metadata={
             "help": "The maximum total sequence length for target text after tokenization. Sequences longer "
-                    "than this will be truncated, sequences shorter will be padded."
+            "than this will be truncated, sequences shorter will be padded."
         },
     )
     max_train_samples: Optional[int] = field(
         default=None,
         metadata={
             "help": "For debugging purposes or quicker training, truncate the number of training examples to this "
-                    "value if set."
+            "value if set."
         },
     )
     max_eval_samples: Optional[int] = field(
         default=None,
         metadata={
             "help": "For debugging purposes or quicker training, truncate the number of evaluation examples to this "
-                    "value if set."
+            "value if set."
         },
     )
 
@@ -147,7 +151,9 @@ class DataTrainingArguments:
 
 
 def main():
-    parser = HfArgumentParser((ModelArguments, DataTrainingArguments, Seq2SeqTrainingArguments))
+    parser = HfArgumentParser(
+        (ModelArguments, DataTrainingArguments, Seq2SeqTrainingArguments)
+    )
     model_args, data_args, training_args = parser.parse_args_into_dataclasses()
 
     # Setup logging
@@ -173,17 +179,23 @@ def main():
 
     # Detecting last checkpoint.
     last_checkpoint = None
-    if os.path.isdir(training_args.output_dir) and training_args.do_train and not training_args.overwrite_output_dir:
+    if (
+        os.path.isdir(training_args.output_dir)
+        and training_args.do_train
+        and not training_args.resume_from_checkpoint
+    ):
         last_checkpoint = get_last_checkpoint(training_args.output_dir)
         if last_checkpoint is None and len(os.listdir(training_args.output_dir)) > 0:
             raise ValueError(
                 f"Output directory ({training_args.output_dir}) already exists and is not empty. "
-                "Use --overwrite_output_dir to overcome."
+                "Use --resume_from_checkpoint to overcome."
             )
-        elif last_checkpoint is not None and training_args.resume_from_checkpoint is None:
+        elif (
+            last_checkpoint is not None and training_args.resume_from_checkpoint is None
+        ):
             logger.info(
                 f"Checkpoint detected, resuming training at {last_checkpoint}. To avoid this behavior, change "
-                "the `--output_dir` or add `--overwrite_output_dir` to train from scratch."
+                "the `--output_dir` or add `--resume_from_checkpoint` to train from scratch."
             )
 
     # Set seed before initializing model.
@@ -197,31 +209,28 @@ def main():
     if data_args.test_file is not None:
         data_files["test"] = data_args.test_file
     print(data_files, data_args.test_file)
-    raw_datasets = load_dataset('json', data_files=data_files)
+    raw_datasets = load_dataset("json", data_files=data_files)
 
     config = AutoConfig.from_pretrained(
-        model_args.model_name_or_path,
-        cache_dir=model_args.cache_dir
+        model_args.model_name_or_path, cache_dir=model_args.cache_dir
     )
     tokenizer = AutoTokenizer.from_pretrained(
-        model_args.model_name_or_path,
-        use_fast=True,
-        cache_dir=model_args.cache_dir
+        model_args.model_name_or_path, use_fast=True, cache_dir=model_args.cache_dir
     )
     model = AutoModelForSeq2SeqLM.from_pretrained(
         model_args.model_name_or_path,
         from_tf=bool(".ckpt" in model_args.model_name_or_path),
         config=config,
-        cache_dir=model_args.cache_dir
+        cache_dir=model_args.cache_dir,
     )
 
     model.resize_token_embeddings(len(tokenizer))
- 
+
     # if model_args.DualEncoder:
     #     DualEncoder_model = DualEncoderT5(model.config)
     #     DualEncoder_model.load_t5(model.state_dict())
     #     model = DualEncoder_model
-        
+
     prefix = data_args.source_prefix if data_args.source_prefix is not None else ""
 
     # Preprocessing the datasets.
@@ -233,32 +242,41 @@ def main():
     elif training_args.do_predict:
         column_names = raw_datasets["test"].column_names
     else:
-        logger.info("There is nothing to do. Please pass `do_train`, `do_eval` and/or `do_predict`.")
+        logger.info(
+            "There is nothing to do. Please pass `do_train`, `do_eval` and/or `do_predict`."
+        )
         return
 
     # Temporarily set max_target_length for training.
     max_target_length = data_args.max_target_length
     padding = False
 
-    if training_args.label_smoothing_factor > 0 and not hasattr(model, "prepare_decoder_input_ids_from_labels"):
+    if training_args.label_smoothing_factor > 0 and not hasattr(
+        model, "prepare_decoder_input_ids_from_labels"
+    ):
         logger.warning(
             "label_smoothing is enabled but the `prepare_decoder_input_ids_from_labels` method is not defined for"
             f"`{model.__class__.__name__}`. This will lead to loss being calculated twice and will take up more memory"
         )
- 
-    
+
     def preprocess_function_original(examples):
-        inputs = [ex for ex in examples['input']]
-        targets = [ex for ex in examples['output']]
+        inputs = [ex for ex in examples["input"]]
+        targets = [ex for ex in examples["output"]]
         inputs = [prefix + inp for inp in inputs]
-        model_inputs = tokenizer(inputs, max_length=data_args.max_source_length, padding=padding, truncation=True)
-        
+        model_inputs = tokenizer(
+            inputs,
+            max_length=data_args.max_source_length,
+            padding=padding,
+            truncation=True,
+        )
+
         with tokenizer.as_target_tokenizer():
-            labels = tokenizer(targets, max_length=max_target_length, padding=padding, truncation=True)
+            labels = tokenizer(
+                targets, max_length=max_target_length, padding=padding, truncation=True
+            )
 
         model_inputs["labels"] = labels["input_ids"]
         return model_inputs
-    
 
     preprocess_function = preprocess_function_original
 
@@ -285,7 +303,9 @@ def main():
         eval_dataset = raw_datasets["validation"]
         if data_args.max_eval_samples is not None:
             eval_dataset = eval_dataset.select(range(data_args.max_eval_samples))
-        with training_args.main_process_first(desc="validation dataset map pre-processing"):
+        with training_args.main_process_first(
+            desc="validation dataset map pre-processing"
+        ):
             eval_dataset = eval_dataset.map(
                 preprocess_function,
                 batched=True,
@@ -301,9 +321,13 @@ def main():
             raise ValueError("--do_predict requires a test dataset")
         predict_dataset = raw_datasets["test"]
         if data_args.max_predict_samples is not None:
-            max_predict_samples = min(len(predict_dataset), data_args.max_predict_samples)
+            max_predict_samples = min(
+                len(predict_dataset), data_args.max_predict_samples
+            )
             predict_dataset = predict_dataset.select(range(max_predict_samples))
-        with training_args.main_process_first(desc="prediction dataset map pre-processing"):
+        with training_args.main_process_first(
+            desc="prediction dataset map pre-processing"
+        ):
             predict_dataset = predict_dataset.map(
                 preprocess_function,
                 batched=True,
@@ -313,9 +337,10 @@ def main():
                 desc="Running tokenizer on prediction dataset",
             )
     # Data collator
-    label_pad_token_id = -100 if data_args.ignore_pad_token_for_loss else tokenizer.pad_token_id
+    label_pad_token_id = (
+        -100 if data_args.ignore_pad_token_for_loss else tokenizer.pad_token_id
+    )
 
-    
     data_collator = DataCollatorForSeq2Seq(
         tokenizer,
         model=model,
@@ -348,17 +373,27 @@ def main():
         result = metric.compute(predictions=decoded_preds, references=decoded_labels)
         result = {"bleu": result["score"]}
 
-        prediction_lens = [np.count_nonzero(pred != tokenizer.pad_token_id) for pred in preds]
+        prediction_lens = [
+            np.count_nonzero(pred != tokenizer.pad_token_id) for pred in preds
+        ]
         result["gen_len"] = np.mean(prediction_lens)
         result["exact_match"] = np.mean(
-            [decoded_preds[idx] == decoded_labels[idx][0] for idx in range(len(decoded_preds))])
+            [
+                decoded_preds[idx] == decoded_labels[idx][0]
+                for idx in range(len(decoded_preds))
+            ]
+        )
         result = {k: round(v, 4) for k, v in result.items()}
         return result
 
     # Initialize our Trainer
     cbs = None
     if model_args.early_stopping_patience > 0:
-        cbs = [EarlyStoppingCallback(early_stopping_patience=model_args.early_stopping_patience)]
+        cbs = [
+            EarlyStoppingCallback(
+                early_stopping_patience=model_args.early_stopping_patience
+            )
+        ]
     trainer = Seq2SeqTrainer(
         model=model,
         args=training_args,
@@ -366,7 +401,9 @@ def main():
         eval_dataset=eval_dataset if training_args.do_eval else None,
         tokenizer=tokenizer,
         data_collator=data_collator,
-        compute_metrics=compute_metrics if training_args.predict_with_generate else None,
+        compute_metrics=compute_metrics
+        if training_args.predict_with_generate
+        else None,
         callbacks=cbs,
     )
 
@@ -382,7 +419,9 @@ def main():
 
         metrics = train_result.metrics
         max_train_samples = (
-            data_args.max_train_samples if data_args.max_train_samples is not None else len(train_dataset)
+            data_args.max_train_samples
+            if data_args.max_train_samples is not None
+            else len(train_dataset)
         )
         metrics["train_samples"] = min(max_train_samples, len(train_dataset))
 
@@ -399,8 +438,14 @@ def main():
     num_beams = training_args.generation_num_beams
     if training_args.do_eval:
         logger.info("*** Evaluate ***")
-        metrics = trainer.evaluate(max_length=max_length, num_beams=num_beams, metric_key_prefix="eval")
-        max_eval_samples = data_args.max_eval_samples if data_args.max_eval_samples is not None else len(eval_dataset)
+        metrics = trainer.evaluate(
+            max_length=max_length, num_beams=num_beams, metric_key_prefix="eval"
+        )
+        max_eval_samples = (
+            data_args.max_eval_samples
+            if data_args.max_eval_samples is not None
+            else len(eval_dataset)
+        )
         metrics["eval_samples"] = min(max_eval_samples, len(eval_dataset))
 
         trainer.log_metrics("eval", metrics)
@@ -410,11 +455,16 @@ def main():
         logger.info("*** Predict ***")
 
         predict_results = trainer.predict(
-            predict_dataset, metric_key_prefix="predict", max_length=max_length, num_beams=num_beams
+            predict_dataset,
+            metric_key_prefix="predict",
+            max_length=max_length,
+            num_beams=num_beams,
         )
         metrics = predict_results.metrics
         max_predict_samples = (
-            data_args.max_predict_samples if data_args.max_predict_samples is not None else len(predict_dataset)
+            data_args.max_predict_samples
+            if data_args.max_predict_samples is not None
+            else len(predict_dataset)
         )
         metrics["predict_samples"] = min(max_predict_samples, len(predict_dataset))
 
@@ -423,13 +473,18 @@ def main():
 
         if training_args.predict_with_generate:
             predictions = tokenizer.batch_decode(
-                    predict_results.predictions, skip_special_tokens=False, clean_up_tokenization_spaces=True
-                )
+                predict_results.predictions,
+                skip_special_tokens=False,
+                clean_up_tokenization_spaces=True,
+            )
             predictions = [pred.strip() for pred in predictions]
-            output_prediction_file = os.path.join(training_args.output_dir, "generated_predictions.txt")
-            #print(predictions)
+            output_prediction_file = os.path.join(
+                training_args.output_dir, "generated_predictions.txt"
+            )
+            # print(predictions)
             with open(output_prediction_file, "w") as writer:
                 writer.write("\n".join(predictions))
+
 
 def _mp_fn(index):
     # For xla_spawn (TPUs)

--- a/llm_blender/pair_ranker/collator.py
+++ b/llm_blender/pair_ranker/collator.py
@@ -1,5 +1,6 @@
 import torch
 
+
 def encode_texts(texts, tokenizer, max_length=None):
     """
     Args:
@@ -8,14 +9,15 @@ def encode_texts(texts, tokenizer, max_length=None):
         input_ids: [n_texts, max_length]
         attention_mask: [n_texts, max_length]
     """
-    p = tokenizer.batch_encode_plus(
+    encoded = tokenizer(
         texts,
         max_length=max_length,
-        padding='max_length',
-        return_tensors='pt',
-        truncation=True
+        padding="max_length",
+        return_tensors="pt",
+        truncation=True,
     )
-    return p['input_ids'], p['attention_mask']
+    return encoded["input_ids"], encoded["attention_mask"]
+
 
 def encode_batch_text(batch_texts, tokenizer, max_length=None):
     """
@@ -36,9 +38,10 @@ def encode_batch_text(batch_texts, tokenizer, max_length=None):
     encoded_masks = torch.cat(encoded_masks, dim=0)
     return encoded_ids, encoded_masks
 
+
 def get_truncated_text(texts, tokenizer, max_length=None):
     """
-        Truncate the texts to max_length
+    Truncate the texts to max_length
     """
     truncated_texts = []
     for text in texts:
@@ -50,6 +53,7 @@ def get_truncated_text(texts, tokenizer, max_length=None):
         )
         truncated_texts.append(tokenizer.decode(tokens, skip_special_tokens=True))
     return truncated_texts
+
 
 class SCRCollator(object):
     def __init__(
@@ -64,36 +68,61 @@ class SCRCollator(object):
         self.source_maxlength = source_maxlength
         self.candidate_maxlength = candidate_maxlength
 
-        self.sep_token = tokenizer.sep_token if tokenizer.sep_token is not None else tokenizer.eos_token
-        self.cls_token = tokenizer.cls_token if tokenizer.cls_token is not None else tokenizer.bos_token
-        assert self.sep_token is not None, 'sep_token is not found in the tokenizer'
+        self.sep_token = (
+            tokenizer.sep_token
+            if tokenizer.sep_token is not None
+            else tokenizer.eos_token
+        )
+        self.cls_token = (
+            tokenizer.cls_token
+            if tokenizer.cls_token is not None
+            else tokenizer.bos_token
+        )
+        assert self.sep_token is not None, "sep_token is not found in the tokenizer"
         self.separate_token = self.sep_token
         self.source_prefix = source_prefix if source_prefix is not None else "<source>"
-        self.candidate_prefix = candidate_prefix if candidate_prefix is not None else "<candidate>"
-        self.model_max_length = min(tokenizer.model_max_length, self.source_maxlength+self.candidate_maxlength+3)
-
+        self.candidate_prefix = (
+            candidate_prefix if candidate_prefix is not None else "<candidate>"
+        )
+        self.model_max_length = min(
+            tokenizer.model_max_length,
+            self.source_maxlength + self.candidate_maxlength + 3,
+        )
 
     def __call__(self, batch):
         batch_size = len(batch)
-        batch_source = [b['source'] for b in batch]
-        batch_candidates = [b['candidates'] for b in batch]
-        if 'scores' in batch[0] and batch[0]['scores'] is not None:
-            batch_scores = torch.tensor([b['scores'] for b in batch])
+        batch_source = [b["source"] for b in batch]
+        batch_candidates = [b["candidates"] for b in batch]
+        if "scores" in batch[0] and batch[0]["scores"] is not None:
+            batch_scores = torch.tensor([b["scores"] for b in batch])
 
-        batch_source = get_truncated_text(batch_source, self.tokenizer, self.source_maxlength)
-        batch_candidates = [get_truncated_text(c, self.tokenizer, self.candidate_maxlength) for c in batch_candidates]
+        batch_source = get_truncated_text(
+            batch_source, self.tokenizer, self.source_maxlength
+        )
+        batch_candidates = [
+            get_truncated_text(c, self.tokenizer, self.candidate_maxlength)
+            for c in batch_candidates
+        ]
 
-        source_texts = [[
-            self.separate_token.join([self.source_prefix+s, self.candidate_prefix+c]) for c in cands] 
-            for s, cands in zip(batch_source, batch_candidates)] # concatenate source and target
-        encoded_source_text_ids, encoded_source_text_masks = encode_batch_text(source_texts, self.tokenizer, self.model_max_length) # source
-
+        source_texts = [
+            [
+                self.separate_token.join(
+                    [self.source_prefix + s, self.candidate_prefix + c]
+                )
+                for c in cands
+            ]
+            for s, cands in zip(batch_source, batch_candidates)
+        ]  # concatenate source and target
+        encoded_source_text_ids, encoded_source_text_masks = encode_batch_text(
+            source_texts, self.tokenizer, self.model_max_length
+        )  # source
 
         return {
-            'input_ids' : encoded_source_text_ids,
-            'attention_mask' : encoded_source_text_masks,
-            'scores' : batch_scores,
+            "input_ids": encoded_source_text_ids,
+            "attention_mask": encoded_source_text_masks,
+            "scores": batch_scores,
         }
+
 
 class DualCollator(object):
     def __init__(
@@ -108,48 +137,67 @@ class DualCollator(object):
         self.source_maxlength = source_maxlength
         self.candidate_maxlength = candidate_maxlength
 
-        self.sep_token = tokenizer.sep_token if tokenizer.sep_token is not None else tokenizer.eos_token
-        self.cls_token = tokenizer.cls_token if tokenizer.cls_token is not None else tokenizer.bos_token
-        assert self.sep_token is not None, 'sep_token is not found in the tokenizer'
+        self.sep_token = (
+            tokenizer.sep_token
+            if tokenizer.sep_token is not None
+            else tokenizer.eos_token
+        )
+        self.cls_token = (
+            tokenizer.cls_token
+            if tokenizer.cls_token is not None
+            else tokenizer.bos_token
+        )
+        assert self.sep_token is not None, "sep_token is not found in the tokenizer"
         self.cls_token = self.cls_token if self.cls_token is not None else ""
-        self.separate_token = self.sep_token + ' ' + self.cls_token # used to separate 2 concatenated texts
+        self.separate_token = (
+            self.sep_token + " " + self.cls_token
+        )  # used to separate 2 concatenated texts
         self.target_maxlength = self.candidate_maxlength
         self.source_prefix = source_prefix if source_prefix is not None else "<source>"
-        self.candidate_prefix = candidate_prefix if candidate_prefix is not None else "<candidate>"
+        self.candidate_prefix = (
+            candidate_prefix if candidate_prefix is not None else "<candidate>"
+        )
 
         tokenizer.add_tokens([self.source_prefix, self.candidate_prefix])
 
-
     def __call__(self, batch):
         batch_size = len(batch)
-        batch_source = [b['source'] for b in batch]
-        batch_target = [b['target'] for b in batch]
-        batch_candidates = [b['candidates'] for b in batch]
-        if 'scores' in batch[0] and batch[0]['scores'] is not None:
-            batch_scores = torch.tensor([b['scores'] for b in batch])
+        batch_source = [b["source"] for b in batch]
+        batch_target = [b["target"] for b in batch]
+        batch_candidates = [b["candidates"] for b in batch]
+        if "scores" in batch[0] and batch[0]["scores"] is not None:
+            batch_scores = torch.tensor([b["scores"] for b in batch])
         else:
             batch_scores = None
-        
 
         # add prefix
         batch_source = [self.source_prefix + s for s in batch_source]
-        batch_candidates = [[self.candidate_prefix + c for c in cands] for cands in batch_candidates]
+        batch_candidates = [
+            [self.candidate_prefix + c for c in cands] for cands in batch_candidates
+        ]
         batch_target = [self.candidate_prefix + t for t in batch_target]
 
         # tokenize
-        encoded_source_ids, encoded_source_masks = encode_texts(batch_source, self.tokenizer, self.source_maxlength) # source
-        encoded_target_ids, encoded_target_masks = encode_texts(batch_target, self.tokenizer, self.candidate_maxlength) # target
-        encoded_candidate_ids, encoded_candidate_masks = encode_batch_text(batch_candidates, self.tokenizer, self.candidate_maxlength) # candidates
+        encoded_source_ids, encoded_source_masks = encode_texts(
+            batch_source, self.tokenizer, self.source_maxlength
+        )  # source
+        encoded_target_ids, encoded_target_masks = encode_texts(
+            batch_target, self.tokenizer, self.candidate_maxlength
+        )  # target
+        encoded_candidate_ids, encoded_candidate_masks = encode_batch_text(
+            batch_candidates, self.tokenizer, self.candidate_maxlength
+        )  # candidates
 
         return {
-            'source_ids' : encoded_source_ids,
-            'source_attention_mask' : encoded_source_masks,
-            'target_ids' : encoded_target_ids,
-            'target_attention_mask' : encoded_target_masks,
-            "candidate_ids" : encoded_candidate_ids,
-            "candidate_attention_mask" : encoded_candidate_masks,
-            'scores' : batch_scores,
+            "source_ids": encoded_source_ids,
+            "source_attention_mask": encoded_source_masks,
+            "target_ids": encoded_target_ids,
+            "target_attention_mask": encoded_target_masks,
+            "candidate_ids": encoded_candidate_ids,
+            "candidate_attention_mask": encoded_candidate_masks,
+            "scores": batch_scores,
         }
+
 
 class CrossCompareCollator(object):
     def __init__(
@@ -165,81 +213,136 @@ class CrossCompareCollator(object):
         self.source_maxlength = source_maxlength
         self.candidate_maxlength = candidate_maxlength
 
-        self.sep_token = tokenizer.sep_token if tokenizer.sep_token is not None else tokenizer.eos_token
-        self.cls_token = tokenizer.cls_token if tokenizer.cls_token is not None else tokenizer.bos_token
-        assert self.sep_token is not None, 'sep_token is not found in the tokenizer'
+        self.sep_token = (
+            tokenizer.sep_token
+            if tokenizer.sep_token is not None
+            else tokenizer.eos_token
+        )
+        self.cls_token = (
+            tokenizer.cls_token
+            if tokenizer.cls_token is not None
+            else tokenizer.bos_token
+        )
+        assert self.sep_token is not None, "sep_token is not found in the tokenizer"
         self.separate_token = self.sep_token
         self.target_maxlength = self.candidate_maxlength
-        self.source_prefix = source_prefix if source_prefix is not None else "<|source|>"
-        self.candidate1_prefix = candidate1_prefix if candidate1_prefix is not None else "<|candidate1|>"
-        self.candidate2_prefix = candidate2_prefix if candidate2_prefix is not None else "<|candidate2|>"
+        self.source_prefix = (
+            source_prefix if source_prefix is not None else "<|source|>"
+        )
+        self.candidate1_prefix = (
+            candidate1_prefix if candidate1_prefix is not None else "<|candidate1|>"
+        )
+        self.candidate2_prefix = (
+            candidate2_prefix if candidate2_prefix is not None else "<|candidate2|>"
+        )
         self.candidate_prefix = "<|candidate|>"
-        self.max_length = min(self.tokenizer.model_max_length, self.source_maxlength + 2 * self.candidate_maxlength + 6)
-        
+        self.max_length = min(
+            self.tokenizer.model_max_length,
+            self.source_maxlength + 2 * self.candidate_maxlength + 6,
+        )
+
         self.mannually_add_sep_token = False
         if len(self.tokenizer.encode(self.sep_token)) == 1:
             self.mannually_add_sep_token = True
             self.sep_token_id_in_list = self.tokenizer.encode(self.sep_token)
 
         # add prefix
-        tokenizer.add_tokens([self.source_prefix, self.candidate1_prefix, self.candidate2_prefix, self.candidate_prefix]) # debug
+        tokenizer.add_tokens(
+            [
+                self.source_prefix,
+                self.candidate1_prefix,
+                self.candidate2_prefix,
+                self.candidate_prefix,
+            ]
+        )  # debug
         tokenizer.source_prefix = self.source_prefix
         tokenizer.candidate1_prefix = self.candidate1_prefix
         tokenizer.candidate2_prefix = self.candidate2_prefix
         tokenizer.candidate_prefix = self.candidate_prefix
         tokenizer.source_prefix_id = tokenizer.convert_tokens_to_ids(self.source_prefix)
-        tokenizer.cand1_prefix_id = tokenizer.convert_tokens_to_ids(self.candidate1_prefix)
-        tokenizer.cand2_prefix_id = tokenizer.convert_tokens_to_ids(self.candidate2_prefix)
-        tokenizer.cand_prefix_id = tokenizer.convert_tokens_to_ids(self.candidate_prefix)
-
+        tokenizer.cand1_prefix_id = tokenizer.convert_tokens_to_ids(
+            self.candidate1_prefix
+        )
+        tokenizer.cand2_prefix_id = tokenizer.convert_tokens_to_ids(
+            self.candidate2_prefix
+        )
+        tokenizer.cand_prefix_id = tokenizer.convert_tokens_to_ids(
+            self.candidate_prefix
+        )
 
     def __call__(self, batch):
-        batch_source = [self.source_prefix+b['source'] for b in batch]
-        batch_candidates = [[self.candidate_prefix+cand for cand in b['candidates']] for b in batch]
+        batch_source = [self.source_prefix + b["source"] for b in batch]
+        batch_candidates = [
+            [self.candidate_prefix + cand for cand in b["candidates"]] for b in batch
+        ]
         # substitute special token into space
-        batch_source = [s.replace(self.sep_token, ' ') for s in batch_source]
-        batch_candidates = [[cand.replace(self.sep_token, ' ') for cand in cands] for cands in batch_candidates]
-        if 'scores' in batch[0] and batch[0]['scores'] is not None:
-            scores = torch.tensor([b['scores'] for b in batch])
+        batch_source = [s.replace(self.sep_token, " ") for s in batch_source]
+        batch_candidates = [
+            [cand.replace(self.sep_token, " ") for cand in cands]
+            for cands in batch_candidates
+        ]
+        if "scores" in batch[0] and batch[0]["scores"] is not None:
+            scores = torch.tensor([b["scores"] for b in batch])
         else:
             scores = None
-        
+
         if self.mannually_add_sep_token:
-            batch_source = get_truncated_text(batch_source, self.tokenizer, self.source_maxlength)
+            batch_source = get_truncated_text(
+                batch_source, self.tokenizer, self.source_maxlength
+            )
             batch_source = [s + self.sep_token for s in batch_source]
             source_ids, source_masks = encode_texts(batch_source, self.tokenizer)
             valid_positions = source_masks.any(dim=0)
             source_ids = source_ids[:, valid_positions]
             source_masks = source_masks[:, valid_positions]
             remaining_length = self.source_maxlength - valid_positions.sum().item()
-            
-            batch_candidates = [get_truncated_text(c, self.tokenizer, self.candidate_maxlength + remaining_length // 2) for c in batch_candidates]
-            batch_candidates = [[cand + self.sep_token for cand in cands] for cands in batch_candidates]
-            candidate_ids, candidate_masks = encode_batch_text(batch_candidates, self.tokenizer)
-            cand_valid_positions = candidate_masks.reshape(-1, candidate_masks.shape[-1]).any(dim=0)
+
+            batch_candidates = [
+                get_truncated_text(
+                    c, self.tokenizer, self.candidate_maxlength + remaining_length // 2
+                )
+                for c in batch_candidates
+            ]
+            batch_candidates = [
+                [cand + self.sep_token for cand in cands] for cands in batch_candidates
+            ]
+            candidate_ids, candidate_masks = encode_batch_text(
+                batch_candidates, self.tokenizer
+            )
+            cand_valid_positions = candidate_masks.reshape(
+                -1, candidate_masks.shape[-1]
+            ).any(dim=0)
             candidate_ids = candidate_ids[:, :, cand_valid_positions]
             candidate_masks = candidate_masks[:, :, cand_valid_positions]
         else:
-            
-            source_ids, source_masks = encode_texts(batch_source, self.tokenizer, self.source_maxlength)
+            source_ids, source_masks = encode_texts(
+                batch_source, self.tokenizer, self.source_maxlength
+            )
             valid_positions = source_masks.any(dim=0)
             source_ids = source_ids[:, valid_positions]
             source_masks = source_masks[:, valid_positions]
             remaining_length = self.source_maxlength - valid_positions.sum().item()
-            
-            candidate_ids, candidate_masks = encode_batch_text(batch_candidates, self.tokenizer, self.candidate_maxlength + remaining_length // 2)
-            cand_valid_positions = candidate_masks.reshape(-1, candidate_masks.shape[-1]).any(dim=0)
+
+            candidate_ids, candidate_masks = encode_batch_text(
+                batch_candidates,
+                self.tokenizer,
+                self.candidate_maxlength + remaining_length // 2,
+            )
+            cand_valid_positions = candidate_masks.reshape(
+                -1, candidate_masks.shape[-1]
+            ).any(dim=0)
             candidate_ids = candidate_ids[:, :, cand_valid_positions]
             candidate_masks = candidate_masks[:, :, cand_valid_positions]
-        
+
         return {
-            "source_ids" : source_ids,
-            "source_attention_mask" : source_masks,
-            "candidate_ids" : candidate_ids,
-            "candidate_attention_mask" : candidate_masks,
-            "scores" : scores,
+            "source_ids": source_ids,
+            "source_attention_mask": source_masks,
+            "candidate_ids": candidate_ids,
+            "candidate_attention_mask": candidate_masks,
+            "scores": scores,
         }
-        
+
+
 class DebertaRMCollator(object):
     def __init__(
         self,
@@ -253,37 +356,50 @@ class DebertaRMCollator(object):
         self.source_maxlength = source_maxlength
         self.candidate_maxlength = candidate_maxlength
 
-        self.sep_token = tokenizer.sep_token if tokenizer.sep_token is not None else tokenizer.eos_token
-        self.cls_token = tokenizer.cls_token if tokenizer.cls_token is not None else tokenizer.bos_token
-        assert self.sep_token is not None, 'sep_token is not found in the tokenizer'
+        self.sep_token = (
+            tokenizer.sep_token
+            if tokenizer.sep_token is not None
+            else tokenizer.eos_token
+        )
+        self.cls_token = (
+            tokenizer.cls_token
+            if tokenizer.cls_token is not None
+            else tokenizer.bos_token
+        )
+        assert self.sep_token is not None, "sep_token is not found in the tokenizer"
         self.separate_token = self.sep_token
         self.source_prefix = source_prefix if source_prefix is not None else ""
         self.candidate_prefix = candidate_prefix if candidate_prefix is not None else ""
         self.model_max_length = tokenizer.model_max_length
 
-
     def __call__(self, batch):
         batch_size = len(batch)
-        batch_source = [b['source'] for b in batch]
-        batch_candidates = [b['candidates'] for b in batch]
+        batch_source = [b["source"] for b in batch]
+        batch_candidates = [b["candidates"] for b in batch]
 
-        batch_source = get_truncated_text(batch_source, self.tokenizer, self.source_maxlength)
-        batch_candidates = [get_truncated_text(c, self.tokenizer, self.candidate_maxlength) for c in batch_candidates]
+        batch_source = get_truncated_text(
+            batch_source, self.tokenizer, self.source_maxlength
+        )
+        batch_candidates = [
+            get_truncated_text(c, self.tokenizer, self.candidate_maxlength)
+            for c in batch_candidates
+        ]
 
         encodings = self.tokenizer(
             [s for s in batch_source for _ in range(len(batch_candidates[0]))],
             [c for cs in batch_candidates for c in cs],
-            padding='longest',
-            return_tensors='pt',
+            padding="longest",
+            return_tensors="pt",
             truncation=False,
             max_length=self.model_max_length,
         )
 
         return {**encodings}
-    
+
 
 class StarlingRMCollator(object):
     template = "<s>[INST] {instruction} </s> [/INST] {completion}</s>"
+
     def __init__(
         self,
         source_maxlength,
@@ -296,28 +412,44 @@ class StarlingRMCollator(object):
         self.source_maxlength = source_maxlength
         self.candidate_maxlength = candidate_maxlength
 
-        self.sep_token = tokenizer.sep_token if tokenizer.sep_token is not None else tokenizer.eos_token
-        self.cls_token = tokenizer.cls_token if tokenizer.cls_token is not None else tokenizer.bos_token
-        assert self.sep_token is not None, 'sep_token is not found in the tokenizer'
+        self.sep_token = (
+            tokenizer.sep_token
+            if tokenizer.sep_token is not None
+            else tokenizer.eos_token
+        )
+        self.cls_token = (
+            tokenizer.cls_token
+            if tokenizer.cls_token is not None
+            else tokenizer.bos_token
+        )
+        assert self.sep_token is not None, "sep_token is not found in the tokenizer"
         self.separate_token = self.sep_token
         self.source_prefix = source_prefix if source_prefix is not None else ""
         self.candidate_prefix = candidate_prefix if candidate_prefix is not None else ""
         self.model_max_length = tokenizer.model_max_length
 
-
     def __call__(self, batch):
         batch_size = len(batch)
-        batch_source = [b['source'] for b in batch]
-        batch_candidates = [b['candidates'] for b in batch]
+        batch_source = [b["source"] for b in batch]
+        batch_candidates = [b["candidates"] for b in batch]
 
-        batch_source = get_truncated_text(batch_source, self.tokenizer, self.source_maxlength)
-        batch_candidates = [get_truncated_text(c, self.tokenizer, self.candidate_maxlength) for c in batch_candidates]
-        
+        batch_source = get_truncated_text(
+            batch_source, self.tokenizer, self.source_maxlength
+        )
+        batch_candidates = [
+            get_truncated_text(c, self.tokenizer, self.candidate_maxlength)
+            for c in batch_candidates
+        ]
+
         input_texts = []
         for i in range(batch_size):
             for j in range(len(batch_candidates[i])):
-                input_texts.append(self.template.format(instruction=batch_source[i], completion=batch_candidates[i][j]))
-        
+                input_texts.append(
+                    self.template.format(
+                        instruction=batch_source[i], completion=batch_candidates[i][j]
+                    )
+                )
+
         encodings = self.tokenizer(
             input_texts,
             truncation=True,
@@ -327,7 +459,7 @@ class StarlingRMCollator(object):
         )
 
         return {**encodings}
-    
+
 
 class UltraRMCollator(object):
     template = "Human: {instruction}\n\nAssistant: {completion}"
@@ -344,32 +476,48 @@ class UltraRMCollator(object):
         self.source_maxlength = source_maxlength
         self.candidate_maxlength = candidate_maxlength
 
-        self.sep_token = tokenizer.sep_token if tokenizer.sep_token is not None else tokenizer.eos_token
-        self.cls_token = tokenizer.cls_token if tokenizer.cls_token is not None else tokenizer.bos_token
-        assert self.sep_token is not None, 'sep_token is not found in the tokenizer'
+        self.sep_token = (
+            tokenizer.sep_token
+            if tokenizer.sep_token is not None
+            else tokenizer.eos_token
+        )
+        self.cls_token = (
+            tokenizer.cls_token
+            if tokenizer.cls_token is not None
+            else tokenizer.bos_token
+        )
+        assert self.sep_token is not None, "sep_token is not found in the tokenizer"
         self.separate_token = self.sep_token
         self.source_prefix = source_prefix if source_prefix is not None else ""
         self.candidate_prefix = candidate_prefix if candidate_prefix is not None else ""
         self.model_max_length = tokenizer.model_max_length
 
-
     def __call__(self, batch):
         batch_size = len(batch)
-        batch_source = [b['source'] for b in batch]
-        batch_candidates = [b['candidates'] for b in batch]
+        batch_source = [b["source"] for b in batch]
+        batch_candidates = [b["candidates"] for b in batch]
 
-        batch_source = get_truncated_text(batch_source, self.tokenizer, self.source_maxlength)
-        batch_candidates = [get_truncated_text(c, self.tokenizer, self.candidate_maxlength) for c in batch_candidates]
-        
+        batch_source = get_truncated_text(
+            batch_source, self.tokenizer, self.source_maxlength
+        )
+        batch_candidates = [
+            get_truncated_text(c, self.tokenizer, self.candidate_maxlength)
+            for c in batch_candidates
+        ]
+
         input_texts = []
         for i in range(batch_size):
             for j in range(len(batch_candidates[i])):
-                input_texts.append(self.template.format(instruction=batch_source[i], completion=batch_candidates[i][j]))
-        
+                input_texts.append(
+                    self.template.format(
+                        instruction=batch_source[i], completion=batch_candidates[i][j]
+                    )
+                )
+
         encodings = self.tokenizer(
             input_texts,
-            padding='longest',
-            return_tensors='pt',
+            padding="longest",
+            return_tensors="pt",
             truncation=False,
             max_length=self.model_max_length,
         )

--- a/llm_blender/pair_ranker/trainer.py
+++ b/llm_blender/pair_ranker/trainer.py
@@ -11,7 +11,9 @@ from transformers import EvalPrediction
 from typing import Dict, List, Optional, Tuple, Union, Any
 from torch.utils.data import Dataset
 from dataclasses import asdict
+
 logger = logging.getLogger(__name__)
+
 
 class RerankerTrainer(Trainer):
     def evaluate(
@@ -28,8 +30,13 @@ class RerankerTrainer(Trainer):
         if self.is_world_process_zero():
             super().save_model(output_dir, **kwargs)
             model = self.model.module if hasattr(self.model, "module") else self.model
-            json.dump(asdict(model.args), open(os.path.join(output_dir, "config.json"), "w"), indent=4)
-            
+            json.dump(
+                asdict(model.args),
+                open(os.path.join(output_dir, "config.json"), "w"),
+                indent=4,
+            )
+
+
 class FiDTrainer(Seq2SeqTrainer):
     def compute_loss(self, model, inputs, return_outputs=False):
         """
@@ -47,11 +54,6 @@ class FiDTrainer(Seq2SeqTrainer):
             labels=inputs["labels"],
         )
 
-        # Save past state if it exists
-        # TODO: this needs to be fixed and made cleaner later.
-        if self.args.past_index >= 0:
-            self._past = outputs[self.args.past_index]
-
         if labels is not None:
             loss = self.label_smoother(outputs, labels)
         else:
@@ -67,30 +69,43 @@ class FiDTrainer(Seq2SeqTrainer):
 
         return (loss, outputs) if return_outputs else loss
 
+
 def compute_metrics_for_scr(eval_pred: EvalPrediction) -> Dict[str, float]:
-    preds, labels = eval_pred # pred_scores [batch_size, num_candidates], scores [batch_size, num_candidates, n_tasks]
+    preds, labels = (
+        eval_pred  # pred_scores [batch_size, num_candidates], scores [batch_size, num_candidates, n_tasks]
+    )
     pred_scores = preds
     scores = labels
-    agg_scores = np.mean(scores, axis=-1) # aggregate scores
+    agg_scores = np.mean(scores, axis=-1)  # aggregate scores
 
-    sort_indices = np.flip(np.argsort(agg_scores, axis=-1), axis=-1) # (batch_size, n_candidates), expected ranks
+    sort_indices = np.flip(
+        np.argsort(agg_scores, axis=-1), axis=-1
+    )  # (batch_size, n_candidates), expected ranks
     ranks = np.zeros_like(sort_indices)
-    ranks[np.arange(sort_indices.shape[0])[:, None], sort_indices] = np.arange(sort_indices.shape[-1])
-    pred_sort_indices = np.flip(np.argsort(pred_scores, axis=-1), axis=-1) # (batch_size, n_candidates), predicted ranks
+    ranks[np.arange(sort_indices.shape[0])[:, None], sort_indices] = np.arange(
+        sort_indices.shape[-1]
+    )
+    pred_sort_indices = np.flip(
+        np.argsort(pred_scores, axis=-1), axis=-1
+    )  # (batch_size, n_candidates), predicted ranks
     pred_ranks = np.zeros_like(pred_sort_indices)
-    pred_ranks[np.arange(pred_sort_indices.shape[0])[:, None], pred_sort_indices] = np.arange(pred_sort_indices.shape[-1])
+    pred_ranks[np.arange(pred_sort_indices.shape[0])[:, None], pred_sort_indices] = (
+        np.arange(pred_sort_indices.shape[-1])
+    )
 
     # compute selection scores
-    sel_idx = np.argmax(pred_scores, axis=1) # [batch_size]
-    sel_scores = scores[np.arange(scores.shape[0]), sel_idx] # [batch_size, n_task]
-    sel_ranks = ranks[np.arange(ranks.shape[0]), sel_idx] # [batch_size]
-    sel_acc = np.mean((sel_ranks == 0)) # scalar
+    sel_idx = np.argmax(pred_scores, axis=1)  # [batch_size]
+    sel_scores = scores[np.arange(scores.shape[0]), sel_idx]  # [batch_size, n_task]
+    sel_ranks = ranks[np.arange(ranks.shape[0]), sel_idx]  # [batch_size]
+    sel_acc = np.mean((sel_ranks == 0))  # scalar
 
     # compute oracle scores for reference
-    oracle_sel_idx = np.argmax(agg_scores, axis=1) # [batch_size]
-    oracle_sel_scores = scores[np.arange(scores.shape[0]), oracle_sel_idx] # [batch_size, n_task]
-    oracle_sel_ranks = ranks[np.arange(ranks.shape[0]), oracle_sel_idx] # [batch_size]
-    oracle_sel_acc = np.mean((oracle_sel_ranks == 0)) # scalar
+    oracle_sel_idx = np.argmax(agg_scores, axis=1)  # [batch_size]
+    oracle_sel_scores = scores[
+        np.arange(scores.shape[0]), oracle_sel_idx
+    ]  # [batch_size, n_task]
+    oracle_sel_ranks = ranks[np.arange(ranks.shape[0]), oracle_sel_idx]  # [batch_size]
+    oracle_sel_acc = np.mean((oracle_sel_ranks == 0))  # scalar
 
     metrics = {
         "sel": {
@@ -101,13 +116,12 @@ def compute_metrics_for_scr(eval_pred: EvalPrediction) -> Dict[str, float]:
             "acc": oracle_sel_acc,
             "rank": np.mean(oracle_sel_ranks),
         },
-        "dev_score": np.mean(sel_scores[:, 0]), # dev score used for save checkpoint,
+        "dev_score": np.mean(sel_scores[:, 0]),  # dev score used for save checkpoint,
     }
     for i in range(sel_scores.shape[-1]):
-        metrics["sel"]["metric{}".format(i+1)] = np.mean(sel_scores[:, i])
-        metrics["oracle"]["metric{}".format(i+1)] = np.mean(oracle_sel_scores[:, i])
+        metrics["sel"]["metric{}".format(i + 1)] = np.mean(sel_scores[:, i])
+        metrics["oracle"]["metric{}".format(i + 1)] = np.mean(oracle_sel_scores[:, i])
     return metrics
-
 
 
 def compute_metrics_for_pairranker(eval_pred: EvalPrediction) -> Dict[str, float]:
@@ -116,12 +130,12 @@ def compute_metrics_for_pairranker(eval_pred: EvalPrediction) -> Dict[str, float
     Args:
 
     """
-    preds, labels = eval_pred # scores [batch_size, n_candidates, n_tasks]
+    preds, labels = eval_pred  # scores [batch_size, n_candidates, n_tasks]
     logits = preds
-    
-    scores = labels # [batch_size, n_candidates, n_tasks]
+
+    scores = labels  # [batch_size, n_candidates, n_tasks]
     # scores = scores[:, :-1] # debug
-    mean_scores = np.mean(scores, axis=-1) # [batch_size, n_candidates]
+    mean_scores = np.mean(scores, axis=-1)  # [batch_size, n_candidates]
     batch_size, n_candidates, n_tasks = scores.shape
 
     # get the predicted best index
@@ -130,7 +144,9 @@ def compute_metrics_for_pairranker(eval_pred: EvalPrediction) -> Dict[str, float
         pred_best_idx = logits[:, 2, -1]
     elif logits.shape == (batch_size, n_candidates, n_candidates):
         # full
-        pred_best_idx = np.argmax(np.mean(logits, axis=2) - np.mean(logits, axis=1), axis=-1)
+        pred_best_idx = np.argmax(
+            np.mean(logits, axis=2) - np.mean(logits, axis=1), axis=-1
+        )
     else:
         raise ValueError("Invalid logits shape: {}".format(logits.shape))
 
@@ -144,12 +160,14 @@ def compute_metrics_for_pairranker(eval_pred: EvalPrediction) -> Dict[str, float
         "gain": {},
     }
     for i in range(n_tasks):
-        metrics["sel"]["metric_{}".format(i+1)] = np.mean(pred_best_scores[:, i])
-        metrics["oracle"]["metric_{}".format(i+1)] = np.mean(oracle_best_scores[:, i])
-        metrics["top_beam"]["metric_{}".format(i+1)] = np.mean(scores[:, 0, i])
-        metrics["gain"]["metric_{}".format(i+1)] = metrics["sel"]["metric_{}".format(i+1)] / metrics["top_beam"]["metric_{}".format(i+1)] - 1
-    metrics['dev_score'] = metrics['sel']['metric_1']
+        metrics["sel"]["metric_{}".format(i + 1)] = np.mean(pred_best_scores[:, i])
+        metrics["oracle"]["metric_{}".format(i + 1)] = np.mean(oracle_best_scores[:, i])
+        metrics["top_beam"]["metric_{}".format(i + 1)] = np.mean(scores[:, 0, i])
+        metrics["gain"]["metric_{}".format(i + 1)] = (
+            metrics["sel"]["metric_{}".format(i + 1)]
+            / metrics["top_beam"]["metric_{}".format(i + 1)]
+            - 1
+        )
+    metrics["dev_score"] = metrics["sel"]["metric_1"]
 
     return metrics
-
-

--- a/train_ranker.py
+++ b/train_ranker.py
@@ -16,31 +16,26 @@ import warnings
 import logging
 from transformers import TrainingArguments
 from transformers.trainer_utils import PredictionOutput, is_main_process
+
 warnings.filterwarnings("ignore")
-from llm_blender.common.utils import (
-    str2bool,
-    empty2None,
-    seed_everything
-)
+from llm_blender.common.utils import str2bool, empty2None, seed_everything
 from llm_blender.pair_ranker.trainer import (
     compute_metrics_for_pairranker,
-    compute_metrics_for_scr
+    compute_metrics_for_scr,
 )
 from llm_blender.pair_ranker.model_util import (
     build_ranker,
     build_tokenizer,
     build_collator,
 )
-from llm_blender.pair_ranker.data import (
-    load_data,
-    Dataset
-)
+from llm_blender.pair_ranker.data import load_data, Dataset
 from llm_blender.pair_ranker.trainer import (
     RerankerTrainer,
 )
 from llm_blender.pair_ranker.config import (
     RankerConfig,
 )
+
 
 def main(args):
     seed_everything(args.seed)
@@ -54,8 +49,10 @@ def main(args):
     tokenizer = build_tokenizer(args.model_name, cache_dir=args.cache_dir)
     # set up data collator, also add prefix as new tokens to tokenizer
     data_collator = build_collator(
-        args.ranker_type, tokenizer,
-        args.source_maxlength, args.candidate_maxlength,
+        args.ranker_type,
+        tokenizer,
+        args.source_maxlength,
+        args.candidate_maxlength,
     )
 
     # set up dataset
@@ -63,17 +60,23 @@ def main(args):
     eval_dataset = None
     predict_dataset = None
     if args.do_train:
-        train_examples = load_data(args.train_data_path, args, max_size=args.max_train_data_size)
+        train_examples = load_data(
+            args.train_data_path, args, max_size=args.max_train_data_size
+        )
         train_dataset = Dataset(train_examples, args.n_candidates)
     if args.do_eval:
-        eval_examples = load_data(args.eval_data_path, args, max_size=args.max_eval_data_size)
+        eval_examples = load_data(
+            args.eval_data_path, args, max_size=args.max_eval_data_size
+        )
         eval_dataset = Dataset(eval_examples, args.n_candidates)
     else:
-        args.evaluation_strategy = 'no'
-        args.save_strategy = 'no'
+        args.evaluation_strategy = "no"
+        args.save_strategy = "no"
 
     if args.do_predict:
-        predict_examples = load_data(args.test_data_path, args, max_size=args.max_predict_data_size)
+        predict_examples = load_data(
+            args.test_data_path, args, max_size=args.max_predict_data_size
+        )
         predict_dataset = Dataset(predict_examples, args.n_candidates)
 
     if args.do_train:
@@ -84,9 +87,11 @@ def main(args):
         args.n_tasks = predict_dataset.n_tasks
 
     # set up model
-    
+
     if args.load_checkpoint:
-        config = RankerConfig.from_json_file(os.path.join(args.load_checkpoint, "config.json"))
+        config = RankerConfig.from_json_file(
+            os.path.join(args.load_checkpoint, "config.json")
+        )
         for k in args.__dict__:
             if k in config.__dict__:
                 print(k, getattr(args, k))
@@ -104,7 +109,9 @@ def main(args):
         if load_result.missing_keys:
             logging.warning(f"Missing keys: {load_result.missing_keys}")
         else:
-            logging.info(f"Successfully loaded checkpoint from '{args.load_checkpoint}'")
+            logging.info(
+                f"Successfully loaded checkpoint from '{args.load_checkpoint}'"
+            )
     else:
         config = RankerConfig()
         for k, v in args.__dict__.items():
@@ -126,7 +133,7 @@ def main(args):
     # set up trainer
     training_args = TrainingArguments(
         output_dir=args.output_dir,
-        overwrite_output_dir=args.overwrite_output_dir,
+        resume_from_checkpoint=True if args.overwrite_output_dir else None,
         do_train=args.do_train,
         do_eval=args.do_eval,
         do_predict=args.do_predict,
@@ -138,8 +145,11 @@ def main(args):
         max_grad_norm=args.max_grad_norm,
         num_train_epochs=args.num_train_epochs,
         max_steps=args.max_steps,
-        warmup_steps=args.warmup_steps,
-        warmup_ratio=args.warmup_ratio,
+        warmup_steps=args.warmup_steps
+        if args.warmup_steps > 0
+        else int(args.warmup_ratio * args.max_steps)
+        if args.max_steps > 0
+        else 0,
         lr_scheduler_type=args.lr_scheduler_type,
         logging_steps=args.logging_steps,
         logging_first_step=args.logging_first_step,
@@ -151,7 +161,7 @@ def main(args):
         seed=args.seed,
         local_rank=args.local_rank,
         fp16=args.fp16,
-        deepspeed=args.deepspeed, #
+        deepspeed=args.deepspeed,  #
         label_names=args.label_names,
         evaluation_strategy=args.evaluation_strategy,
         save_strategy=args.save_strategy,
@@ -187,7 +197,7 @@ def main(args):
             wandb.init(project="Reranker", group=args.ranker_type, name=args.run_name)
             wandb.config.update(args)
         else:
-            os.environ["WANDB_DISABLED"] = 'true'
+            os.environ["WANDB_DISABLED"] = "true"
 
         if args.evaluate_before_training:
             metrics = trainer.evaluate()
@@ -236,45 +246,95 @@ def main(args):
                 torch.save(labels, f)
             logging.info(f"predictions saved to {output_path}")
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     # model config
-    parser.add_argument("--ranker_type", type=str, choices=[
-        "summareranker", "dual", "pairranker"
-    ], default="sc")
-    parser.add_argument("--model_type", type=str, choices=[
-        "roberta", "bert", "t5", 'deberta', 'xlm-roberta', 'flan-t5', 'alpaca', 'opt', 'phi'
-    ], default="roberta")
+    parser.add_argument(
+        "--ranker_type",
+        type=str,
+        choices=["summareranker", "dual", "pairranker"],
+        default="sc",
+    )
+    parser.add_argument(
+        "--model_type",
+        type=str,
+        choices=[
+            "roberta",
+            "bert",
+            "t5",
+            "deberta",
+            "xlm-roberta",
+            "flan-t5",
+            "alpaca",
+            "opt",
+            "phi",
+        ],
+        default="roberta",
+    )
     parser.add_argument("--model_name", type=str, default="roberta-base")
     parser.add_argument("--load_checkpoint", type=empty2None, default=None)
     parser.add_argument("--cache_dir", type=str, default=None)
-    parser.add_argument("--loss_type", type=str, choices=[
-      "BCE", "MSE", "instructgpt", "MoE_BCE", "simcls", "open_instruct_BCE"
-    ], default="BCE")
+    parser.add_argument(
+        "--loss_type",
+        type=str,
+        choices=["BCE", "MSE", "instructgpt", "MoE_BCE", "simcls", "open_instruct_BCE"],
+        default="BCE",
+    )
 
     # data config
     parser.add_argument("--n_candidates", type=int, default=-1)
-    parser.add_argument("--candidate_decoding_method", type=empty2None, default=None, help="separted by comma. Empty string for all methods")
-    parser.add_argument("--candidate_model", type=empty2None, default=None, help="separted by comma. Empty string for all models")
+    parser.add_argument(
+        "--candidate_decoding_method",
+        type=empty2None,
+        default=None,
+        help="separted by comma. Empty string for all methods",
+    )
+    parser.add_argument(
+        "--candidate_model",
+        type=empty2None,
+        default=None,
+        help="separted by comma. Empty string for all models",
+    )
     parser.add_argument("--source_maxlength", type=int, default=256)
     parser.add_argument("--candidate_maxlength", type=int, default=256)
     parser.add_argument("--num_pos", type=int, default=1)
     parser.add_argument("--num_neg", type=int, default=1)
     parser.add_argument("--sub_sampling_ratio", type=float, default=0.4)
-    parser.add_argument("--sub_sampling_mode", type=str, choices=[
-        "uniform", "top_bottom", "top_random", "random_bottom", "random", 
-        "uniform", "all_pair"
-    ], default="top_bottom")
+    parser.add_argument(
+        "--sub_sampling_mode",
+        type=str,
+        choices=[
+            "uniform",
+            "top_bottom",
+            "top_random",
+            "random_bottom",
+            "random",
+            "uniform",
+            "all_pair",
+        ],
+        default="top_bottom",
+    )
     parser.add_argument("--max_train_data_size", type=int, default=-1)
     parser.add_argument("--max_eval_data_size", type=int, default=-1)
     parser.add_argument("--max_predict_data_size", type=int, default=-1)
-    parser.add_argument("--using_metrics", type=str, default="rouge1,rouge2,rougeLsum", help="Metrics used for training")
+    parser.add_argument(
+        "--using_metrics",
+        type=str,
+        default="rouge1,rouge2,rougeLsum",
+        help="Metrics used for training",
+    )
 
     # running config
     parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument('--fp16', type=str2bool, default=True)
-    parser.add_argument('--deepspeed', type=str, default=None) # "ds_config.json"
-    parser.add_argument("--local_rank", type=int, default=-1, help="Local rank. Necessary for using the torch.distributed.launch utility.")
+    parser.add_argument("--fp16", type=str2bool, default=True)
+    parser.add_argument("--deepspeed", type=str, default=None)  # "ds_config.json"
+    parser.add_argument(
+        "--local_rank",
+        type=int,
+        default=-1,
+        help="Local rank. Necessary for using the torch.distributed.launch utility.",
+    )
 
     # mode
     parser.add_argument("--do_train", type=str2bool, default=True)
@@ -291,19 +351,34 @@ if __name__ == "__main__":
     parser.add_argument("--num_train_epochs", type=int, default=3)
     parser.add_argument("--max_steps", type=int, default=-1)
     parser.add_argument("--warmup_ratio", type=float, default=0.05)
-    parser.add_argument("--warmup_steps", type=int, default=0) # Overrides any effect of :obj:`warmup_ratio`.
-    parser.add_argument("--lr_scheduler_type", type=str, choices=[
-        "linear", "cosine", "cosine_with_restarts", "polynomial", "constant", "constant_with_warmup"
-    ], default="linear")
-    parser.add_argument('--adafactor', type=bool, default=True)
+    parser.add_argument(
+        "--warmup_steps", type=int, default=0
+    )  # Overrides any effect of :obj:`warmup_ratio`.
+    parser.add_argument(
+        "--lr_scheduler_type",
+        type=str,
+        choices=[
+            "linear",
+            "cosine",
+            "cosine_with_restarts",
+            "polynomial",
+            "constant",
+            "constant_with_warmup",
+        ],
+        default="linear",
+    )
+    parser.add_argument("--adafactor", type=bool, default=True)
 
     # evaluation hyperparameters
     parser.add_argument("--eval_data_path", type=str, default=None)
     parser.add_argument("--per_device_eval_batch_size", type=int, default=8)
     parser.add_argument("--evaluate_before_training", type=str2bool, default=False)
-    parser.add_argument("--evaluation_strategy", type=str, choices=[
-        "steps", "epoch", "no"
-    ], default="epoch")
+    parser.add_argument(
+        "--evaluation_strategy",
+        type=str,
+        choices=["steps", "epoch", "no"],
+        default="epoch",
+    )
     parser.add_argument("--eval_steps", type=int, default=0)
 
     # predict config
@@ -313,17 +388,21 @@ if __name__ == "__main__":
     # logging
     parser.add_argument("--logging_first_step", type=str2bool, default=True)
     parser.add_argument("--logging_steps", type=int, default=5)
-    parser.add_argument("--log_level", type=str, default="passive",
-        choices=["passive", "info", "debug", "warning", "error", "critical"])
-    parser.add_argument("--report_to", type=str, default='none')
-    parser.add_argument("--run_name", type=str, default="basic") # wandb run name
+    parser.add_argument(
+        "--log_level",
+        type=str,
+        default="passive",
+        choices=["passive", "info", "debug", "warning", "error", "critical"],
+    )
+    parser.add_argument("--report_to", type=str, default="none")
+    parser.add_argument("--run_name", type=str, default="basic")  # wandb run name
 
     # save config
     parser.add_argument("--output_dir", type=str, default=None)
     parser.add_argument("--overwrite_output_dir", type=str2bool, default=False)
-    parser.add_argument("--save_strategy", type=str, choices=[
-        "steps", "epoch", "no"
-    ], default="epoch")
+    parser.add_argument(
+        "--save_strategy", type=str, choices=["steps", "epoch", "no"], default="epoch"
+    )
     parser.add_argument("--save_steps", type=int, default=0)
     parser.add_argument("--save_total_limit", type=int, default=4)
 
@@ -333,21 +412,30 @@ if __name__ == "__main__":
     parser.add_argument("--metric_for_best_model", type=str, default="dev_score")
 
     # inference config
-    parser.add_argument("--inference_mode", type=str, default="bubble",
-        choices=["bubble", "full"])
+    parser.add_argument(
+        "--inference_mode", type=str, default="bubble", choices=["bubble", "full"]
+    )
 
     # init args
     args = parser.parse_args()
     args.load_best_model_at_end = args.do_train and args.do_predict
     # set up default output dir
     if args.output_dir is None:
-        args.output_dir = f"outputs/{args.ranker_type}/{args.model_name}/{args.run_name}"
-    args.cache_dir = "./hf_models/" + args.model_name.split('/')[-1] + "/"
+        args.output_dir = (
+            f"outputs/{args.ranker_type}/{args.model_name}/{args.run_name}"
+        )
+    args.cache_dir = "./hf_models/" + args.model_name.split("/")[-1] + "/"
     args.label_names = ["scores"]
-    args.candidate_decoding_methods = args.candidate_decoding_method.split(',') if args.candidate_decoding_method is not None else None
-    args.candidate_models = args.candidate_model.split(',') if args.candidate_model is not None else None
+    args.candidate_decoding_methods = (
+        args.candidate_decoding_method.split(",")
+        if args.candidate_decoding_method is not None
+        else None
+    )
+    args.candidate_models = (
+        args.candidate_model.split(",") if args.candidate_model is not None else None
+    )
     args.local_rank = os.environ.get("LOCAL_RANK", args.local_rank)
-    args.metrics = args.using_metrics.split(',')
+    args.metrics = args.using_metrics.split(",")
 
     # set up logging
     if args.log_level == "passive":


### PR DESCRIPTION
- Replace deprecated `TRANSFORMERS_CACHE` with `HF_HOME` from `huggingface_hub` (dup. of https://github.com/yuchenlin/LLM-Blender/pull/34)
- Replace `batch_encode_plus with tokenizer()` call (removed in v5)
- Use `BitsAndBytesConfig` instead of `load_in_4bit`/`oad_in_8bit` params
- Remove `past_index` usage in `FiDTrainer` (removed in v5)
- Add proper initialization of instance variables in Blender

Fixes: https://github.com/huggingface/trl/issues/4918 
Fixes: https://github.com/yuchenlin/LLM-Blender/issues/33